### PR TITLE
feat(chat): Windows 顶栏改为全宽标题栏带

### DIFF
--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -16,8 +16,17 @@ pub const CHAT_MIN_INNER_HEIGHT: f64 = 400.0;
 const CHAT_DEFAULT_INNER_WIDTH: f64 = 1280.0;
 const CHAT_DEFAULT_INNER_HEIGHT: f64 = 800.0;
 
+/// Windows / Linux 的自绘全宽标题栏带高度（与 index.css `.chat-titlebar-strip { height: 44px }` 同步）。
+/// macOS 用系统 Overlay 标题栏、不占额外内容高度，故为 0。
+#[cfg(target_os = "macos")]
+const CHAT_TITLEBAR_STRIP_HEIGHT: f64 = 0.0;
+#[cfg(not(target_os = "macos"))]
+const CHAT_TITLEBAR_STRIP_HEIGHT: f64 = 44.0;
+
+/// 把「可见内容所需尺寸」换算成窗口 inner 尺寸：非 macOS 要额外容纳那条标题栏带，
+/// 否则小窗下带会吃掉 44px 内容高度，把输入框挤出可视区。
 fn chat_window_size_for_visible_content(width: f64, height: f64) -> (f64, f64) {
-    (width, height)
+    (width, height + CHAT_TITLEBAR_STRIP_HEIGHT)
 }
 
 pub fn apply_chat_window_min_size(window: &WebviewWindow, sidebar_expanded: bool) {

--- a/src/chat/Chat.tsx
+++ b/src/chat/Chat.tsx
@@ -22,6 +22,7 @@ import {
   isChatSkillCenterPath,
 } from './chatRoutes'
 import { ChatImageViewer } from './ChatImageViewer'
+import { ChatTitlebar } from './ChatTitlebar'
 import { ChatTitlebarActions } from './ChatTitlebarActions'
 import type { AssistantStreamStats } from './MessageList'
 import { InputBar } from './InputBar'
@@ -30,7 +31,6 @@ import { ThinkingLevelSelector } from './ThinkingLevelSelector'
 import { ExternalModelSelector, RuntimePicker } from './RuntimePicker'
 import { PermissionPicker } from './PermissionPicker'
 import { BackgroundJobsIndicator } from './BackgroundJobsIndicator'
-import { WindowControls } from './WindowControls'
 import { ContextIndicator } from './ContextIndicator'
 import { AgentTodoIndicator } from './AgentTodoIndicator'
 import { isExecutableAgentPlanText } from './agentPlan'
@@ -3543,15 +3543,14 @@ export default function Chat({ onSettingsChange, onContentReady }: ChatProps) {
   // 带高 24px（低于各中心页 pt-7/py-6 的内容起点），不遮挡任何可交互内容；
   // 收起态按钮行复用会话页收起态顶栏的同一套行高/缩进类（52px 行 + mac 交通灯缩进），
   // 保证收起/展开、中心页/会话页之间按钮位置完全不跳。
-  const centerPageTopStrip = (
+  //
+  // 仅 macOS 需要：Windows / Linux 的 ChatTitlebar 是一条常驻全宽带，
+  // 拖拽区与那两枚按钮本就在带里且不随侧栏收展移动，这条兜底带纯属重复。
+  const centerPageTopStrip = usesNativeTitlebar ? (
     <div className="absolute inset-x-0 top-0 z-20 h-6" data-tauri-drag-region>
       {sidebarCollapsed && (
         <div
-          className={`chat-titlebar-row ${chatTitlebarRowClass} ${
-            usesNativeTitlebar
-              ? `${chatTitlebarMacInsetClass} chat-titlebar-row--collapsed-mac`
-              : 'px-3'
-          }`}
+          className={`chat-titlebar-row ${chatTitlebarRowClass} ${chatTitlebarMacInsetClass} chat-titlebar-row--collapsed-mac`}
           data-tauri-drag-region
         >
           <ChatTitlebarActions
@@ -3562,14 +3561,113 @@ export default function Chat({ onSettingsChange, onContentReady }: ChatProps) {
         </div>
       )}
     </div>
+  ) : null
+
+  // 中心页为上方那条收起态按钮行让出的高度（Windows / Linux 无此行，见 centerPageTopStrip）。
+  const centerPagePadTop = usesNativeTitlebar && sidebarCollapsed ? 'pt-12' : ''
+
+  // 会话页顶栏控件。非 mac 渲染进全宽标题栏带（单行 chrome），mac 仍留在主区 52px 顶栏。
+  // 抽成变量而非组件：依赖十余个 Chat 局部状态与回调，拆组件只会换来一长串 props。
+  const conversationTitlebarControls = (
+    <>
+      <div className="flex min-w-0 items-center gap-1">
+        <div className="shrink-0" data-tauri-drag-region="false">
+          <RuntimePicker
+            agentRuntime={activeAgentRuntime}
+            onRuntimeChange={handleRuntimeChange}
+            conversationId={currentConversation?.id}
+            locked={
+              !!currentConversation &&
+              (currentConversation.messages?.length ?? 0) > 0 &&
+              usesExternalRuntime
+            }
+          />
+        </div>
+        <div className="min-w-0 max-w-full shrink" data-tauri-drag-region="false">
+          {usesExternalRuntime ? (
+            <ExternalModelSelector
+              agentRuntime={activeAgentRuntime}
+              onModelChange={handleExternalModelChange}
+              conversationId={currentConversation?.id}
+            />
+          ) : (
+            <ModelSelector
+              currentProviderId={activeProviderId}
+              currentModel={activeModel}
+              onModelChange={handleModelChange}
+            />
+          )}
+        </div>
+        {!usesExternalRuntime && (
+          <div className="shrink-0 chat-thinking-pill-wrap" data-tauri-drag-region="false">
+            <ThinkingLevelSelector
+              currentProviderId={activeProviderId}
+              currentModel={activeModel}
+              value={
+                currentConversation
+                  ? (currentConversation.thinking_level
+                      ?? currentConversation.thinkingLevel
+                      ?? draftThinkingLevel)
+                  : draftThinkingLevel
+              }
+              onChange={handleThinkingLevelChange}
+            />
+          </div>
+        )}
+        <div className="shrink-0" data-tauri-drag-region="false">
+          <PermissionPicker
+            agentRuntime={activeAgentRuntime}
+            conversationId={currentConversation?.id}
+            onSandboxChange={handleExternalSandboxChange}
+            approvalPolicy={approvalPolicy}
+            onApprovalPolicyChange={handleApprovalPolicyChange}
+          />
+        </div>
+        <div className="shrink-0" data-tauri-drag-region="false">
+          <BackgroundJobsIndicator />
+        </div>
+      </div>
+      <div className="min-w-5 flex-1" data-tauri-drag-region />
+      <div className="flex min-w-0 shrink items-center justify-end gap-1">
+        <div className="shrink-0" data-tauri-drag-region="false">
+          <IconButton
+            label={i18n[uiLang].dockToggle}
+            size="sm"
+            variant="ghost"
+            className={dockOpen ? 'bg-black/5 text-neutral-800 dark:bg-white/10 dark:text-neutral-100' : ''}
+            onClick={handleToggleDock}
+          >
+            <PanelRight size={15} />
+          </IconButton>
+        </div>
+        <AgentTodoIndicator todoState={currentConversation?.agent_todo_state ?? currentConversation?.agentTodoState ?? null} />
+      </div>
+    </>
   )
 
   return (
     <div
       className={`chat-window-shell${usesNativeTitlebar ? ' chat-window-shell--native-titlebar' : ''}`}
     >
-      {!usesNativeTitlebar && <WindowControls />}
-      <div className="flex h-full min-h-0 w-full">
+      {!usesNativeTitlebar && (
+        <ChatTitlebar
+          sidebarExpanded={!sidebarCollapsed}
+          /* 与下方 <Sidebar collapsed> 取反同源：设置页里侧栏也是收起的，
+             只看 sidebarCollapsed 会在设置页多留 240px 空档。 */
+          sidebarVisible={!(sidebarCollapsed || settingsPanelActive)}
+          settingsMode={settingsPanelActive}
+          onToggleSidebar={() => {
+            if (sidebarCollapsed) setSidebarCollapsedPersisted(false)
+            else handleCollapseSidebar()
+          }}
+          onNewConversation={() => {
+            runAfterLeavingSettings(() => void handleNewConversation())
+          }}
+        >
+          {chatView === 'conversation' ? conversationTitlebarControls : null}
+        </ChatTitlebar>
+      )}
+      <div className="flex min-h-0 w-full flex-1">
         {chatView !== 'onboarding' ? (
         /* 设置页自带 200px 导航栏，聊天侧栏此时借用已有的折叠过渡整体滑出（不再直接卸载，
            否则左列会先空一帧、且关闭时侧栏是瞬间 pop 回来的）。退场期保持折叠，
@@ -3604,7 +3702,7 @@ export default function Chat({ onSettingsChange, onContentReady }: ChatProps) {
         ) : null}
 
         {chatView === 'onboarding' ? (
-          <div className="chat-win-titlebar-safe flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
             <OnboardingShell
               onComplete={handleOnboardingExit}
               onSkip={handleOnboardingExit}
@@ -3619,7 +3717,9 @@ export default function Chat({ onSettingsChange, onContentReady }: ChatProps) {
             <SettingsEnterPane
               key="settings"
               exiting={settingsExiting}
-              className="chat-win-titlebar-safe flex min-h-0 min-w-0 flex-1 flex-col"
+              className={`flex min-h-0 min-w-0 flex-1 flex-col${
+                !usesNativeTitlebar && settingsPanelActive ? ' settings-embedded-under-strip' : ''
+              }`}
             >
               <SettingsShell
                 ref={settingsRef}
@@ -3633,7 +3733,7 @@ export default function Chat({ onSettingsChange, onContentReady }: ChatProps) {
             </SettingsEnterPane>
           </Suspense>
         ) : chatView === 'assistants' ? (
-          <div key="assistants" className={`chat-motion-view-in chat-win-titlebar-safe relative flex min-h-0 min-w-0 flex-1 flex-col ${sidebarCollapsed ? 'pt-12' : ''}`}>
+          <div key="assistants" className={`chat-motion-view-in relative flex min-h-0 min-w-0 flex-1 flex-col ${centerPagePadTop}`}>
             {centerPageTopStrip}
             <Suspense fallback={null}>
               <AssistantCenter
@@ -3646,35 +3746,35 @@ export default function Chat({ onSettingsChange, onContentReady }: ChatProps) {
             </Suspense>
           </div>
         ) : chatView === 'skill' ? (
-          <div key="skill" className={`chat-motion-view-in chat-win-titlebar-safe relative flex min-h-0 min-w-0 flex-1 flex-col ${sidebarCollapsed ? 'pt-12' : ''}`}>
+          <div key="skill" className={`chat-motion-view-in relative flex min-h-0 min-w-0 flex-1 flex-col ${centerPagePadTop}`}>
             {centerPageTopStrip}
             <Suspense fallback={null}>
               <SkillCenter onSkillsChanged={() => void loadSkills()} />
             </Suspense>
           </div>
         ) : chatView === 'mcp' ? (
-          <div key="mcp" className={`chat-motion-view-in chat-win-titlebar-safe relative flex min-h-0 min-w-0 flex-1 flex-col ${sidebarCollapsed ? 'pt-12' : ''}`}>
+          <div key="mcp" className={`chat-motion-view-in relative flex min-h-0 min-w-0 flex-1 flex-col ${centerPagePadTop}`}>
             {centerPageTopStrip}
             <Suspense fallback={null}>
               <McpCenter />
             </Suspense>
           </div>
         ) : chatView === 'knowledge' ? (
-          <div key="knowledge" className={`chat-motion-view-in chat-win-titlebar-safe relative flex min-h-0 min-w-0 flex-1 flex-col ${sidebarCollapsed ? 'pt-12' : ''}`}>
+          <div key="knowledge" className={`chat-motion-view-in relative flex min-h-0 min-w-0 flex-1 flex-col ${centerPagePadTop}`}>
             {centerPageTopStrip}
             <Suspense fallback={null}>
               <KnowledgeCenter />
             </Suspense>
           </div>
         ) : chatView === 'notes' ? (
-          <div key="notes" className={`chat-motion-view-in chat-win-titlebar-safe relative flex min-h-0 min-w-0 flex-1 flex-col ${sidebarCollapsed ? 'pt-12' : ''}`}>
+          <div key="notes" className={`chat-motion-view-in relative flex min-h-0 min-w-0 flex-1 flex-col ${centerPagePadTop}`}>
             {centerPageTopStrip}
             <Suspense fallback={null}>
               <NotesCenter />
             </Suspense>
           </div>
         ) : chatView === 'plugins' ? (
-          <div key="plugins" className={`chat-motion-view-in chat-win-titlebar-safe relative flex min-h-0 min-w-0 flex-1 flex-col ${sidebarCollapsed ? 'pt-12' : ''}`}>
+          <div key="plugins" className={`chat-motion-view-in relative flex min-h-0 min-w-0 flex-1 flex-col ${centerPagePadTop}`}>
             {centerPageTopStrip}
             <Suspense fallback={null}>
               <PluginCenter onRequestAiInstall={handleRequestPluginAiInstall} />
@@ -3685,14 +3785,17 @@ export default function Chat({ onSettingsChange, onContentReady }: ChatProps) {
             {/* 图片查看器为浮层(见下方 overlay),不替换主面板 —— 否则会卸载 InputBar,
                 丢掉待发送附件 / 草稿。here 起正常内容,始终挂载。 */}
             <>
+                {/* 非 mac 的顶栏控件已并进全宽标题栏带（见上方 ChatTitlebar），此行只 mac 渲染。 */}
+                {usesNativeTitlebar && (
                 <header
               className={`chat-titlebar-row ${chatTitlebarRowClass} min-w-0 gap-2 ${
-                sidebarCollapsed && usesNativeTitlebar
-                  ? `${chatTitlebarMacInsetClass} chat-titlebar-row--collapsed-mac`
+                sidebarCollapsed
+                  ? `${chatTitlebarMacInsetClass} chat-titlebar-row--collapsed-mac pr-3`
                   : 'px-6'
-              } ${sidebarCollapsed ? 'pr-3' : ''} ${!usesNativeTitlebar ? 'chat-win-titlebar-safe' : ''}`}
+              }`}
               data-tauri-drag-region
             >
+              {/* mac 收起态把这两枚按钮借到主区顶栏、给交通灯让位。 */}
               {sidebarCollapsed && (
                 <ChatTitlebarActions
                   sidebarExpanded={false}
@@ -3702,79 +3805,9 @@ export default function Chat({ onSettingsChange, onContentReady }: ChatProps) {
                   }}
                 />
               )}
-              <div className="flex min-w-0 items-center gap-1">
-                <div className="shrink-0" data-tauri-drag-region="false">
-                  <RuntimePicker
-                    agentRuntime={activeAgentRuntime}
-                    onRuntimeChange={handleRuntimeChange}
-                    conversationId={currentConversation?.id}
-                    locked={
-                      !!currentConversation &&
-                      (currentConversation.messages?.length ?? 0) > 0 &&
-                      usesExternalRuntime
-                    }
-                  />
-                </div>
-                <div className="min-w-0 max-w-full shrink" data-tauri-drag-region="false">
-                  {usesExternalRuntime ? (
-                    <ExternalModelSelector
-                      agentRuntime={activeAgentRuntime}
-                      onModelChange={handleExternalModelChange}
-                      conversationId={currentConversation?.id}
-                    />
-                  ) : (
-                    <ModelSelector
-                      currentProviderId={activeProviderId}
-                      currentModel={activeModel}
-                      onModelChange={handleModelChange}
-                    />
-                  )}
-                </div>
-                {!usesExternalRuntime && (
-                  <div className="shrink-0 chat-thinking-pill-wrap" data-tauri-drag-region="false">
-                    <ThinkingLevelSelector
-                      currentProviderId={activeProviderId}
-                      currentModel={activeModel}
-                      value={
-                        currentConversation
-                          ? (currentConversation.thinking_level
-                              ?? currentConversation.thinkingLevel
-                              ?? draftThinkingLevel)
-                          : draftThinkingLevel
-                      }
-                      onChange={handleThinkingLevelChange}
-                    />
-                  </div>
-                )}
-                <div className="shrink-0" data-tauri-drag-region="false">
-                  <PermissionPicker
-                    agentRuntime={activeAgentRuntime}
-                    conversationId={currentConversation?.id}
-                    onSandboxChange={handleExternalSandboxChange}
-                    approvalPolicy={approvalPolicy}
-                    onApprovalPolicyChange={handleApprovalPolicyChange}
-                  />
-                </div>
-                <div className="shrink-0" data-tauri-drag-region="false">
-                  <BackgroundJobsIndicator />
-                </div>
-              </div>
-              <div className="min-w-5 flex-1" data-tauri-drag-region />
-              <div className="flex min-w-0 shrink items-center justify-end gap-1">
-                <div className="shrink-0" data-tauri-drag-region="false">
-                  <IconButton
-                    label={i18n[uiLang].dockToggle}
-                    size="sm"
-                    variant="ghost"
-                    className={dockOpen ? 'bg-black/5 text-neutral-800 dark:bg-white/10 dark:text-neutral-100' : ''}
-                    onClick={handleToggleDock}
-                  >
-                    <PanelRight size={15} />
-                  </IconButton>
-                </div>
-                <AgentTodoIndicator todoState={currentConversation?.agent_todo_state ?? currentConversation?.agentTodoState ?? null} />
-              </div>
+              {conversationTitlebarControls}
                 </header>
+                )}
 
                 <div className="flex min-h-0 flex-1 flex-col">
                   {showEmptyHero ? (

--- a/src/chat/ChatTitlebar.tsx
+++ b/src/chat/ChatTitlebar.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from 'react'
+import { ChatTitlebarActions } from './ChatTitlebarActions'
+import { WindowControls } from './WindowControls'
+
+type ChatTitlebarProps = {
+  sidebarExpanded: boolean
+  onToggleSidebar: () => void
+  onNewConversation: () => void
+  /** 侧栏卡片当前是否占位。true 时业务控件让到主区那一列，与主内容左缘对齐。 */
+  sidebarVisible?: boolean
+  /**
+   * 设置页语境：带改为浮在内容之上（不占行高），左段不放按钮。
+   *
+   * 设置页的 200px 灰导航栏是齐窗口左缘的实心列，带若仍是独立一行，灰栏上方会横着
+   * 一条主背景白带 —— 那就是顶栏「突兀」的来源。带浮起后导航栏自己从 y=0 画起，
+   * 宽度与底色全归它一家管；这很关键，因为它的宽度由 `@container settings-shell`
+   * 收窄（200→52px），而容器在内容行内，带在容器外收不到那个查询，无法跟随。
+   *
+   * 左段留空：「侧栏开合 / 新建聊天」在设置页无意义（聊天侧栏已被导航栏顶掉），
+   * 「返回对话」导航栏底部已有一枚，不重复放。带保持全宽透明，故窗口拖拽区不丢。
+   */
+  settingsMode?: boolean
+  /** 会话页的业务控件（模型 / 思考档位 / 权限 / Dock 等）。中心页传 null，带内只剩导航与三键。 */
+  children?: ReactNode
+}
+
+/**
+ * Windows / Linux 的全宽标题栏带（macOS 走系统 Overlay 标题栏，不渲染此组件）。
+ *
+ * 贯穿窗口全宽：左端常驻「侧栏开合 + 新建聊天」，中段是会话页业务控件，右端贴角 caption 键。
+ * 业务控件并进这一条 —— 非 mac 不再有主区 52px 顶栏，chrome 只此一行。
+ * 侧栏展开时导航区撑到侧栏宽，业务控件随之让到主区一列（否则它们压在侧栏卡片上方，读作错位）。
+ * 侧栏卡片 / Dock / 主内容都在带下方开始，所以三键不压内容，
+ * 各视图也不必各自留出躲避空间（旧的 `.chat-win-titlebar-safe` 与中心页兜底拖拽带因此删除）。
+ */
+export function ChatTitlebar({
+  sidebarExpanded,
+  onToggleSidebar,
+  onNewConversation,
+  sidebarVisible = false,
+  settingsMode = false,
+  children,
+}: ChatTitlebarProps) {
+  return (
+    <div
+      className={`chat-titlebar-strip${settingsMode ? ' chat-titlebar-strip--settings' : ''}`}
+      data-tauri-drag-region
+    >
+      {!settingsMode && (
+        <div
+          className={`chat-titlebar-strip-nav${sidebarVisible ? ' chat-titlebar-strip-nav--reserve' : ''}`}
+          data-tauri-drag-region
+        >
+          <ChatTitlebarActions
+            sidebarExpanded={sidebarExpanded}
+            onToggleSidebar={onToggleSidebar}
+            onNewConversation={onNewConversation}
+          />
+        </div>
+      )}
+      <div
+        className="flex min-w-0 flex-1 items-center gap-1 self-stretch"
+        data-tauri-drag-region
+      >
+        {children}
+      </div>
+      <WindowControls />
+    </div>
+  )
+}

--- a/src/chat/Sidebar.tsx
+++ b/src/chat/Sidebar.tsx
@@ -28,7 +28,7 @@ import { getSettingsCached } from '../api/settingsCache'
 import { IconButton } from '../components/Button'
 import { chatApi } from './api'
 import { ChatTitlebarActions } from './ChatTitlebarActions'
-import { chatTitlebarMacInsetClass, isMac } from './platform'
+import { chatTitlebarMacInsetClass, isMac, usesNativeTitlebar } from './platform'
 import type { ConversationMenuAnchor } from './ConversationContextMenu'
 import type { ChatUserProfile } from './types'
 import { UserAvatar } from './UserAvatar'
@@ -934,19 +934,26 @@ export const Sidebar = memo(function Sidebar({
         }`}
         aria-hidden={collapsed}
       >
-        <div
-          className={`chat-titlebar-row chat-sidebar-titlebar-row flex shrink-0 gap-2 ${chatTitlebarMacInsetClass} pr-3`}
-          data-tauri-drag-region
-        >
-          <ChatTitlebarActions
-            sidebarExpanded
-            onToggleSidebar={onToggleCollapsed}
-            onNewConversation={onNewConversation}
-          />
-          <div className="min-w-0 flex-1" data-tauri-drag-region />
-        </div>
+        {/* 侧栏内顶栏行只在 macOS 存在：那两枚按钮要贴着系统交通灯排。
+            Windows / Linux 已把它们常驻到全宽标题栏带（见 ChatTitlebar），此处渲染会重复。 */}
+        {usesNativeTitlebar && (
+          <div
+            className={`chat-titlebar-row chat-sidebar-titlebar-row flex shrink-0 gap-2 ${chatTitlebarMacInsetClass} pr-3`}
+            data-tauri-drag-region
+          >
+            <ChatTitlebarActions
+              sidebarExpanded
+              onToggleSidebar={onToggleCollapsed}
+              onNewConversation={onNewConversation}
+            />
+            <div className="min-w-0 flex-1" data-tauri-drag-region />
+          </div>
+        )}
 
-      <nav className="shrink-0 space-y-0.5 px-3 pb-2" data-tauri-drag-region="false">
+      <nav
+        className={`shrink-0 space-y-0.5 px-3 pb-2 ${usesNativeTitlebar ? '' : 'pt-2'}`}
+        data-tauri-drag-region="false"
+      >
         <NavRow
           icon={<SquarePen size={17} strokeWidth={1.75} />}
           label="新建聊天"

--- a/src/chat/WindowControls.tsx
+++ b/src/chat/WindowControls.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import { Minus, Square, X } from 'lucide-react'
 import { api } from '../api/tauri'
 import { isMac } from './platform'
 
@@ -9,6 +8,33 @@ const trafficColors: Record<TrafficButton, string> = {
   close: '#ff5f57',
   minimize: '#febc2e',
   maximize: '#28c840',
+}
+
+/**
+ * Windows caption 图标：10×10 viewBox 内自绘，笔画恒为 1px（`shape-rendering: crispEdges`
+ * 让它落在整像素网格上，与系统 / Chrome 的锐利实线一致）。
+ *
+ * 刻意不用 lucide：lucide 的 strokeWidth 是 24-viewBox 内的比例，缩到 ~11px 后实际笔画
+ * 只剩 0.6px，抗锯齿会把它糊成一条浅灰虚影；且 lucide `Square` 自带 rx=2 圆角，
+ * 而原生最大化键是直角方框。
+ */
+function CaptionIcon({ kind }: { kind: TrafficButton }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1"
+      shapeRendering="crispEdges"
+      aria-hidden
+    >
+      {kind === 'minimize' && <path d="M0 5.5h10" />}
+      {kind === 'maximize' && <rect x="0.5" y="0.5" width="9" height="9" />}
+      {kind === 'close' && <path d="M0.5 0.5l9 9M9.5 0.5l-9 9" />}
+    </svg>
+  )
 }
 
 export function WindowControls() {
@@ -28,10 +54,10 @@ export function WindowControls() {
     return (
       <div className="chat-win-controls chat-win-controls--win" data-tauri-drag-region="false">
         <button type="button" className="chat-win-btn" onClick={handleMinimize} aria-label="最小化">
-          <Minus size={14} strokeWidth={1.9} aria-hidden />
+          <CaptionIcon kind="minimize" />
         </button>
         <button type="button" className="chat-win-btn" onClick={handleMaximize} aria-label="最大化">
-          <Square size={12} strokeWidth={1.9} aria-hidden />
+          <CaptionIcon kind="maximize" />
         </button>
         <button
           type="button"
@@ -39,7 +65,7 @@ export function WindowControls() {
           onClick={handleClose}
           aria-label="关闭"
         >
-          <X size={14} strokeWidth={2.1} aria-hidden />
+          <CaptionIcon kind="close" />
         </button>
       </div>
     )

--- a/src/index.css
+++ b/src/index.css
@@ -532,6 +532,9 @@ body {
   height: 100%;
   width: 100%;
   display: flex;
+  /* Windows / Linux：第一行是全宽标题栏带，第二行才是侧栏 + 主区（见 .chat-titlebar-strip）。
+     macOS 用系统 Overlay 标题栏、不渲染那条带，此时只有内容一行，column 与 row 等价。 */
+  flex-direction: column;
   overflow: hidden;
   border-radius: 14px;
   border: 1px solid rgba(0, 0, 0, 0.06);
@@ -570,11 +573,6 @@ body {
   border: none;
   border-radius: 0;
   box-shadow: none;
-}
-
-.chat-window-host--maximized .chat-win-controls--win {
-  top: 8px;
-  right: 8px;
 }
 
 /* macOS 原生 Overlay 标题栏：去掉自绘圆角边框，交给系统窗口壳 */
@@ -2996,6 +2994,66 @@ button.chat-composer-status-item:hover {
   background: #28c840;
 }
 
+/* Windows / Linux 全宽标题栏带：无独立底色（透出窗口底色）、无底边框，整条可拖拽。
+   会话页的业务控件也在这一条里 —— 非 mac 没有主区 52px 顶栏，chrome 只此一行，
+   所以高度按 32px 胶囊控件取 44（38 只够放三键，装不下控件）。
+   侧栏卡片 / Dock / 主区都在带下方，故三键可贴角、不必让各视图 padding-right 躲开。
+   左 8px 与侧栏卡片 margin:8 对齐，两枚图标钮与卡片左缘同一条垂线。 */
+.chat-titlebar-strip {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 2px;
+  height: 44px;
+  padding-left: 8px;
+}
+
+/* 带内导航区（侧栏开合 + 新建）。侧栏展开时撑到侧栏那一列的宽度，
+   把业务控件推到主内容左缘 —— 否则控件压在侧栏卡片上方，读作错位。
+   宽度 = 侧栏 240 + 卡片左 margin 8 − 带自身 padding-left 8 = 240，
+   与 `.chat-sidebar-shell` 的 w-[240px] + margin:8 同步（改一处必改另一处）。
+   用 min-width 而非 width 做过渡：width 的收起态是 auto（按钮自然宽），auto 不可插值、
+   动画会直接跳；min-width 两端都是具体值，且 max(内容宽, min-width) 天然贴合按钮宽度，
+   不必把「两枚 28px 钮 + 2px 间距」这种数字硬编码进来。
+   曲线与时长同侧栏折叠（--kv-dur-slow / --kv-ease-standard），两者才像一起移动。 */
+.chat-titlebar-strip-nav {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+  transition: min-width var(--kv-dur-slow) var(--kv-ease-standard);
+}
+
+.chat-titlebar-strip-nav--reserve {
+  min-width: 240px;
+}
+
+/* 设置页：带浮起、不占行高，让 200/52px 灰导航栏自己从 y=0 画起（见 ChatTitlebar 注释）。
+   带保持全宽且透明 —— 全宽才留住窗口拖拽区，透明才让导航栏的灰透上来。
+   只有右端三键是实体，故 z-index 压在内容上层。 */
+.chat-titlebar-strip--settings {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  padding-left: 0;
+}
+
+/* 带浮起后导航栏顶到 y=0：为带让出 44px（+ 原 16px 内边距 = 60），
+   否则窄栏（52px 图标轨，标题被隐藏）第一枚图标会钻到带底下点不到。
+   宽栏里标题也靠这 60 回到与「带占一行」时相同的视觉高度。 */
+.settings-embedded-under-strip .settings-embedded-nav {
+  padding-top: 60px;
+}
+
+/* 页头右侧为三键让位（三键 3×46=138 + 呼吸 12）。只此一处需要 ——
+   下方 .kv-scroll 在页头之下，不会钻到带里。 */
+.settings-embedded-under-strip .settings-embedded-header {
+  padding-right: 150px;
+}
+
 .chat-win-controls {
   display: flex;
   align-items: center;
@@ -3003,54 +3061,37 @@ button.chat-composer-status-item:hover {
   flex-shrink: 0;
 }
 
+/* Windows caption 键规格：46 宽、方角、无容器（无描边 / 无阴影 / 无毛玻璃）。
+   高度撑满整条带并贴住窗口顶边 —— 原生 caption 键的命中区就是顶到窗口边缘的
+   （最大化后鼠标甩到屏幕顶角仍能点中）。刻意不做垂直居中：带 38 − 键 32 的那 6px
+   会在 hover 填色时露成「红块上下各缺一条」。 */
 .chat-win-controls--win {
-  position: absolute;
-  top: 12px;
-  right: 12px;
-  z-index: 40;
-  height: 34px;
-  padding: 0 5px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.04),
-    0 8px 24px rgba(0, 0, 0, 0.08);
-  backdrop-filter: blur(18px);
-}
-
-.dark .chat-win-controls--win {
-  border-color: rgba(255, 255, 255, 0.1);
-  background: rgba(33, 33, 33, 0.92);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.22),
-    0 8px 24px rgba(0, 0, 0, 0.3);
+  gap: 0;
+  align-self: stretch;
 }
 
 .chat-win-btn {
   display: grid;
-  width: 32px;
-  height: 24px;
+  width: 46px;
+  height: 100%;
   place-items: center;
   border: none;
   background: transparent;
-  color: #606068;
-  border-radius: 9999px;
+  color: #1f1f23;
+  border-radius: 0;
   line-height: 1;
   cursor: default;
   transition:
     background-color 0.14s ease,
-    color 0.14s ease,
-    transform 0.14s ease;
+    color 0.14s ease;
 }
 
 .chat-win-btn:hover {
   background: rgba(0, 0, 0, 0.055);
-  color: #1f1f23;
 }
 
 .chat-win-btn:active {
-  transform: scale(0.94);
+  background: rgba(0, 0, 0, 0.09);
 }
 
 .chat-win-btn--close:hover {
@@ -3058,13 +3099,21 @@ button.chat-composer-status-item:hover {
   color: #fff;
 }
 
+.chat-win-btn--close:active {
+  background: #f1707a;
+  color: #fff;
+}
+
 .dark .chat-win-btn {
-  color: #a3a3aa;
+  color: #e8e8ea;
 }
 
 .dark .chat-win-btn:hover {
   background: rgba(255, 255, 255, 0.08);
-  color: #f5f5f5;
+}
+
+.dark .chat-win-btn:active {
+  background: rgba(255, 255, 255, 0.13);
 }
 
 .dark .chat-win-btn--close:hover {
@@ -3072,12 +3121,9 @@ button.chat-composer-status-item:hover {
   color: #fff;
 }
 
-.chat-win-titlebar-safe .chat-titlebar-row,
-.chat-titlebar-row.chat-win-titlebar-safe,
-.chat-win-titlebar-safe .settings-embedded-header,
-.chat-win-titlebar-safe .assistant-center-header,
-.chat-win-titlebar-safe .onboarding-topbar {
-  padding-right: 132px;
+.dark .chat-win-btn--close:active {
+  background: #f1707a;
+  color: #fff;
 }
 
 @container chat-window (max-width: 520px) {


### PR DESCRIPTION
## 背景

Windows 的三键原先是个**悬浮胶囊**（描边 + 双层阴影 + `backdrop-blur`，`absolute` 定在右上角），浮在内容之上，于是每个视图都得靠 `padding-right: 132px` 去躲它。顶栏也不成一行：切栏/新建塞在侧栏卡片内部，模型/思考/权限在主区另一行 52px 顶栏里。

参照 Claude Desktop 的 Windows 顶栏改成一条贯穿窗口全宽的标题栏带。

## 改了什么

**新增 `src/chat/ChatTitlebar.tsx`** — 44px 全宽带：左端常驻侧栏开合 + 新建，中段会话页业务控件，右端贴角 caption 键。侧栏卡片 / Dock / 主内容都从带下方开始。

**caption 键按原生几何自绘** — 10×10 viewBox、1px 直角笔画、`shape-rendering: crispEdges`。不再用 lucide：它的 `strokeWidth` 是 24-viewBox 内的比例，缩到 ~11px 后实际笔画只剩 **0.6px**，抗锯齿糊成一条浅灰虚影；且 lucide `Square` 自带 `rx=2` 圆角，而原生最大化键是直角。键高撑满整条带并贴住窗口顶边 —— 原生 caption 键的命中区就是顶到窗口边缘的（最大化后鼠标甩到屏幕顶角仍能点中）。

**侧栏展开时业务控件跟着让位** — 带内导航区撑到侧栏宽（240px），控件随之对齐主内容左缘，否则它们压在侧栏卡片上方读作错位。用 `min-width` 而非 `width` 做过渡：收起态的 `width` 是 `auto`，`auto` 不可插值、动画会直接跳；`min-width` 两端都是具体值，且 `max(内容宽, min-width)` 天然贴合按钮宽度，不必把按钮尺寸硬编码进来。曲线与时长同侧栏折叠，两者才像一起移动。

**设置页带改为浮起、不占行高** — 让 200px 灰导航栏自己从 `y=0` 画起，否则灰栏上方会横着一条主背景白带。

> 这里有个约束值得 reviewer 注意：导航栏宽度由 `@container settings-shell (max-width: 820px)` 收窄（200→52px），而**容器在内容行内、带在容器外，收不到那个查询**。所以带无法复刻导航栏宽度（我先试过，窄窗时灰块死守 200px 而导航栏已收到 52px），只能让开。带保持全宽透明：全宽才留住窗口拖拽区，透明才让导航栏的灰透上来。

**删除** — `.chat-win-titlebar-safe` 的 `padding-right: 132px` 及 9 处引用、`--maximized` 的胶囊定位覆写、中心页兜底拖拽带（非 mac）。

## macOS 未改动

仍走系统 Overlay 标题栏 + 原生交通灯。主区 52px 顶栏、中心页兜底拖拽带、侧栏卡片内顶栏行、交通灯留白全部按 `usesNativeTitlebar` 保留，mac 分支一行未动。

## 验证

`npm run typecheck` / `npm run lint` 干净，Vitest **526/526**，`cargo check` 通过，`npm run dev` 真机跑起来了。

以下为浏览器内 DOM 实测（取 `getBoundingClientRect` + 计算样式，非肉眼看截图）：

| 项 | 实测 |
|---|---|
| caption 键 | 46 宽、贴顶 `gapAbove/gapBelow = 0`、`position: static`、无圆角/阴影/backdrop |
| 最大化时关闭键 | 抵 (winW, 0) 真正的角 |
| 侧栏展开 | 导航区右缘 248 = 侧栏卡片右缘；首个控件图标 x=257 vs 主内容 x=256（差 1px，按钮盒多出的是 ghost 钮 hover 热区） |
| 侧栏收起 | 导航区收回 58px，控件贴 x=68 |
| 设置页 | 带 `absolute` / y=0 / 全宽 / z-index 30 / 无左段 |
| 设置页导航栏 | 宽态 200px、窄态 **52px**（容器查询正常）；两态 `padding-top: 60px`，窄态首项距 nav 顶 60px（避开 44 带高） |
| 最小宽度 412px | 末个控件右缘 272、caption 键起于 274 —— 不重叠 |

## 已知待确认 / 取舍

- **真机 DWM 接缝**：设置页灰色是否真的贯通到窗口顶、以及带与 DWM 圆角的交界，浏览器测不到原生边框，建议 reviewer 在真机扫一眼。浏览器里设置面板本体加载不了（`invoke` 需 Tauri IPC），上表中导航栏几何是用真实 class 结构的探针量的。
- **一处耦合**：导航区的 240px 与 `.chat-sidebar-shell` 的 `w-[240px]` + `margin: 8` 绑定，改侧栏宽度必须同步改这里 —— 已写进 CSS 注释。
- **未加溢出折叠**：控件靠 `ModelSelector` 自身收缩撑住，412px 最小宽度下实测不挤，真挤到了再说。
- **`chat_window_size_for_visible_content` 非 mac 加 44px**，避免小窗下带吃掉内容高度把输入框挤出可视区；mac 为 0，最小尺寸不变。
- **未跑 `cargo test`**：本次仅动一个尺寸常量，且 Windows 需走 `scripts/win-cargo-test.ps1`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
