### PR TITLE
chore(release): v2.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,16 @@ Kivio Desktop 常驻托盘 / 菜单栏，工作在整个**屏幕**层面，而�
 
 Kivio Desktop 启动后会检查 GitHub Releases 的新版本（可关闭），并支持应用内直接下载安装更新。
 
-## 新版本 —— v2.9.0
+## 新版本 —— v2.9.1
+
+- **DeepSeek Harness** —— 补齐图片、附件路径、停任务（含子代理）和斜杠发现；模型图片与推理档写回已有路由；第三方供应商握手不再空转。空白机器可一键安装并填官方密钥。凭据按官方分层识别环境变量、凭据文件和 `.env`，第三方路由用各自的密钥环境变量，不再误拦。
+- **外部 CLI 系统提示** —— 对话所属集的系统提示会注入外部 CLI，切集不再丢掉那一层人设。
+- **供应商模型列表** —— 拉模型按协议鉴权，并解析 Gemini 原生 ListModels。
+- **启动体验** —— 启动后可最小化到托盘；开机自启不再强行弹出聊天窗。
+- **聊天** —— 工作台路径挪到 tools 之后，避免跨会话打穿前缀缓存。
+- **发版** —— GitHub Actions 同时打包 Windows 与 macOS。
+
+## v2.9.0
 
 - **DeepSeek Harness** —— 新增 dsh 作为外部 CLI 代理：官方供应商、四档 Agent 模式、插件页、斜杠命令（已知命令高亮）、工具卡、压缩，以及 `/compact` `/goal` `/feedback`。重启或改启动配置后仍续上原生会话；顶栏显示实际模型与思考档。后台子代理显示实时进度，完成后把汇报写回父对话，和官方 web 一致。用量条不再把已排除的缓存输入减第二次。
 - **外部 CLI 更稳** —— 每个 CLI 记住上次的模型和思考档，切走再切回不再重置成 Auto。轮内重连保留原生会话，不再开空白对话。Grok 上游 503/429 的静默重试会显示状态。发送失败回填草稿。找不到原生会话时按 ACP 口径降级，不再硬失败。生成中禁止删消息，避免误回收附件。
@@ -427,7 +436,16 @@ All hotkeys act as toggles and are remappable in Settings (with conflict detecti
 
 Kivio Desktop checks GitHub Releases for updates shortly after launch (can be disabled) and can download and install the update in-app.
 
-## What's New — v2.9.0
+## What's New — v2.9.1
+
+- **DeepSeek Harness** — adds images, attachment paths, stop-task (including subagents), and slash discovery; writes model image/reasoning capabilities back onto existing routes; third-party provider handshake no longer spins. A blank machine can one-click install and save the official key. Credentials follow the official layers (env, credentials file, `.env`); third-party routes use their own key env vars instead of being blocked.
+- **External CLI system prompt** — a collection's system prompt is injected into the external CLI, so switching collections no longer drops that identity layer.
+- **Provider model lists** — listing models authenticates per protocol and parses Gemini's native ListModels.
+- **Launch** — can minimize to the tray after start; launch-at-startup no longer forces the chat window open.
+- **Chat** — the workbench path moves after tools, so switching conversations no longer busts the prefix cache.
+- **Release** — GitHub Actions packages Windows and macOS in the same workflow.
+
+## v2.9.0
 
 - **DeepSeek Harness** — dsh joins as an external CLI: official provider, four Agent presets, a plugins page, slash commands (known ones highlighted), tool cards, compaction, and `/compact` `/goal` `/feedback`. Restarts and launch-config changes keep the native session; the title bar shows the model and effort actually in use. Background subagents show live progress and write the report back into the parent conversation when they finish, matching official DSH web. The usage strip no longer subtracts already-excluded cached input a second time.
 - **More reliable external CLIs** — each CLI remembers its last model and thinking level; switching away and back no longer resets the pills to Auto. A mid-turn reconnect keeps the native session instead of opening a blank one. Grok's silent 503/429 retries surface as status notes. A failed send restores the draft. A missing native session degrades the ACP way instead of hard-failing. Messages cannot be deleted while generating, so attachments are not garbage-collected by mistake.

--- a/docs/releases/v2.9.1.md
+++ b/docs/releases/v2.9.1.md
@@ -1,0 +1,32 @@
+# Kivio Desktop v2.9.1
+
+桌面 AI 助手 · macOS (Apple Silicon) + Windows。Desktop AI assistant for macOS (Apple Silicon) and Windows.
+
+## 下载 / Downloads
+
+- **Windows** — `Kivio.Desktop_2.9.1_x64-setup.exe`（NSIS 安装包 / installer）
+- **macOS** — `Kivio.Desktop_2.9.1_aarch64.dmg`（Apple Silicon，未签名 / unsigned）
+  - 首次启动：右键 → 打开，或运行 `xattr -cr "/Applications/Kivio Desktop.app"`
+  - First launch: right-click → Open, or run `xattr -cr "/Applications/Kivio Desktop.app"`
+
+## 新版本亮点
+
+- **DeepSeek Harness** —— 补齐图片、附件路径、停任务（含子代理）和斜杠发现；模型图片与推理档写回已有路由；第三方供应商握手不再空转。空白机器可一键安装并填官方密钥。凭据按官方分层识别环境变量、凭据文件和 `.env`，第三方路由用各自的密钥环境变量，不再误拦。
+- **外部 CLI 系统提示** —— 对话所属集的系统提示会注入外部 CLI，切集不再丢掉那一层人设。
+- **供应商模型列表** —— 拉模型按协议鉴权，并解析 Gemini 原生 ListModels。
+- **启动体验** —— 启动后可最小化到托盘；开机自启不再强行弹出聊天窗。
+- **聊天** —— 工作台路径挪到 tools 之后，避免跨会话打穿前缀缓存。
+- **发版** —— GitHub Actions 同时打包 Windows 与 macOS。
+
+## What's New
+
+- **DeepSeek Harness** — adds images, attachment paths, stop-task (including subagents), and slash discovery; writes model image/reasoning capabilities back onto existing routes; third-party provider handshake no longer spins. A blank machine can one-click install and save the official key. Credentials follow the official layers (env, credentials file, `.env`); third-party routes use their own key env vars instead of being blocked.
+- **External CLI system prompt** — a collection's system prompt is injected into the external CLI, so switching collections no longer drops that identity layer.
+- **Provider model lists** — listing models authenticates per protocol and parses Gemini's native ListModels.
+- **Launch** — can minimize to the tray after start; launch-at-startup no longer forces the chat window open.
+- **Chat** — the workbench path moves after tools, so switching conversations no longer busts the prefix cache.
+- **Release** — GitHub Actions packages Windows and macOS in the same workflow.
+
+---
+
+完整变更 / Full changelog: https://github.com/ZMGID/kivio/compare/v2.9.0...v2.9.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kivio",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kivio",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@lobehub/icons": "^5.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kivio",
   "private": true,
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Kivio Desktop - Screen-level AI assistant for macOS and Windows",
   "license": "GPL-3.0-or-later",
   "author": "ZM",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3217,7 +3217,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kivio"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 # Kivio Rust 后端 Cargo 配置
 [package]
 name = "kivio"
-version = "2.9.1",
+version = "2.9.1"
 description = "Kivio Desktop - Screen-level AI assistant for macOS/Windows"
 authors = ["ZM"]
 license = "GPL-3.0-or-later"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 # Kivio Rust 后端 Cargo 配置
 [package]
 name = "kivio"
-version = "2.9.0"
+version = "2.9.1",
 description = "Kivio Desktop - Screen-level AI assistant for macOS/Windows"
 authors = ["ZM"]
 license = "GPL-3.0-or-later"

--- a/src-tauri/resources/dsh/kivio-dsh-bridge.mjs
+++ b/src-tauri/resources/dsh/kivio-dsh-bridge.mjs
@@ -292,7 +292,7 @@ async function materializeContentBlocks(ctx, blocks) {
 }
 
 export const name = 'kivio-dsh-jsonrpc-bridge'
-export const inject = ['agents', 'sessionPersistence', 'agentPresets', 'userQuestions', 'commands', 'attachments', 'jobs']
+export const inject = ['agents', 'sessionPersistence', 'agentPresets', 'userQuestions', 'commands', 'attachments', 'jobs', 'subagents']
 export const Config = Schema.object({
   maxTokensAsSuccess: Schema.boolean().default(false),
 })

--- a/src-tauri/src/external_agents/dsh_plugins.rs
+++ b/src-tauri/src/external_agents/dsh_plugins.rs
@@ -7,7 +7,8 @@
 //!（那份由 `dsh_profile::ensure_profile_ready` 每轮重写），所以：
 //!
 //! - **官方密钥**：写入 `.credentials.yaml` 的 `DEEPSEEK_API_KEY`，与官方网页版首次
-//!   填密钥同一条路径；不进 `cordis.patch.yml`。
+//!   填密钥同一条路径；不进 `cordis.patch.yml`。就绪判定对齐官方分层：进程环境 >
+//!   `.credentials.yaml` > 项目 `.env` > `$DSH_HOME/.env`。
 //! - **插件配置**：读写 `settings.yaml` + 可选写凭据，热重载后 kivio / web 共用。
 //! - **插件列表**：优先 `dsh --profile kivio --dump-config`（boot-free）解析
 //!   id / name / disabled；失败则读安装包里的 `dsh-base` / `dsh-agent-presets`
@@ -42,6 +43,7 @@ const AGENT_LOOP_NS: &str = "agent-loop";
 const WEB_SEARCH_NS: &str = "web-search-deepseek";
 const LLM_PI_AI_NS: &str = "llm-pi-ai";
 const CREDENTIALS_FILENAME: &str = ".credentials.yaml";
+const DOTENV_FILENAME: &str = ".env";
 const DEFAULT_API_KEY_ENV: &str = "DEEPSEEK_API_KEY";
 const DSH_OFFICIAL_PROVIDER_ID: &str = "deepseek-official";
 
@@ -203,15 +205,34 @@ fn namespace_map<'a>(root: &'a Mapping, key: &str) -> Option<&'a Mapping> {
 }
 
 fn credential_status(api_key_env: &str) -> (bool, bool) {
-    if std::env::var_os(api_key_env)
-        .is_some_and(|value| !value.is_empty())
-    {
+    credential_status_with_files(
+        api_key_env,
+        credentials_path().ok().as_deref(),
+        user_dotenv_path().as_deref(),
+        None,
+    )
+}
+
+fn credential_status_with_files(
+    api_key_env: &str,
+    credentials: Option<&Path>,
+    user_env: Option<&Path>,
+    project_env: Option<&Path>,
+) -> (bool, bool) {
+    if std::env::var_os(api_key_env).is_some_and(|value| !value.is_empty()) {
         return (true, false);
     }
-    let configured = credentials_path()
-        .ok()
-        .is_some_and(|path| credentials_contain(&path, api_key_env));
+    if credentials.is_some_and(|path| credentials_contain(path, api_key_env)) {
+        return (true, true);
+    }
+    // Official layering: managed yaml, then project `.env`, then `$DSH_HOME/.env`.
+    let configured = project_env.is_some_and(|path| dotenv_contains(path, api_key_env))
+        || user_env.is_some_and(|path| dotenv_contains(path, api_key_env));
     (configured, true)
+}
+
+fn user_dotenv_path() -> Option<PathBuf> {
+    dsh_home().map(|home| home.join(DOTENV_FILENAME))
 }
 
 fn credentials_contain(path: &Path, api_key_env: &str) -> bool {
@@ -225,6 +246,83 @@ fn credentials_contain(path: &Path, api_key_env: &str) -> bool {
         .as_mapping()
         .and_then(|map| mapping_string(map, api_key_env))
         .is_some()
+}
+
+fn dotenv_contains(path: &Path, api_key_env: &str) -> bool {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    dotenv_has_key(&text, api_key_env)
+}
+
+fn dotenv_has_key(text: &str, api_key_env: &str) -> bool {
+    for raw in text.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let line = line
+            .strip_prefix("export ")
+            .map(str::trim)
+            .unwrap_or(line);
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() != api_key_env {
+            continue;
+        }
+        let value = value.trim();
+        let unquoted = if value.len() >= 2
+            && ((value.starts_with('"') && value.ends_with('"'))
+                || (value.starts_with('\'') && value.ends_with('\'')))
+        {
+            &value[1..value.len() - 1]
+        } else {
+            value
+        };
+        if !unquoted.is_empty() {
+            return true;
+        }
+    }
+    false
+}
+
+fn pi_ai_api_key_env_from_settings(text: &str, provider_id: &str) -> Option<String> {
+    let value = serde_yaml::from_str::<serde_yaml::Value>(text).ok()?;
+    namespace_map(value.as_mapping()?, LLM_PI_AI_NS)
+        .and_then(|pi| namespace_map(pi, "providers"))
+        .and_then(|providers| {
+            providers
+                .get(serde_yaml::Value::String(provider_id.to_string()))
+                .and_then(serde_yaml::Value::as_mapping)
+        })
+        .and_then(|provider| mapping_string(provider, "apiKeyEnv"))
+}
+
+fn native_pi_ai_api_key_env(provider_id: &str) -> Option<String> {
+    let path = settings_path().ok()?;
+    let text = std::fs::read_to_string(path).ok()?;
+    pi_ai_api_key_env_from_settings(&text, provider_id)
+}
+
+/// Connect 前的凭据门：Kivio 托管供应商由调用方另行判断；这里覆盖官方 DeepSeek
+/// 与 `settings.yaml` 里的 `llm-pi-ai` 路由（含 `.env` 兜底）。
+pub(crate) fn credentials_ready_for_provider(provider: &str, cwd: Option<&Path>) -> bool {
+    let api_key_env = if provider.trim().is_empty() || provider == DSH_OFFICIAL_PROVIDER_ID {
+        DEFAULT_API_KEY_ENV.to_string()
+    } else if let Some(env) = native_pi_ai_api_key_env(provider) {
+        env
+    } else {
+        return false;
+    };
+    let project_env = cwd.map(|path| path.join(DOTENV_FILENAME));
+    credential_status_with_files(
+        &api_key_env,
+        credentials_path().ok().as_deref(),
+        user_dotenv_path().as_deref(),
+        project_env.as_deref(),
+    )
+    .0
 }
 
 fn parse_settings_snapshot(text: &str, settings_path: &Path) -> Result<DshPluginSettingsSnapshot, String> {
@@ -1494,5 +1592,89 @@ llm-pi-ai:
         assert!(text.contains("xhigh"));
         assert!(text.matches("image").count() >= 2);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dotenv_parser_accepts_export_quotes_and_skips_empty() {
+        assert!(dotenv_has_key("DEEPSEEK_API_KEY=sk-test\n", "DEEPSEEK_API_KEY"));
+        assert!(dotenv_has_key(
+            "export DEEPSEEK_API_KEY=sk-test\n",
+            "DEEPSEEK_API_KEY"
+        ));
+        assert!(dotenv_has_key(
+            "DEEPSEEK_API_KEY=\"sk-test\"\n",
+            "DEEPSEEK_API_KEY"
+        ));
+        assert!(dotenv_has_key(
+            "DEEPSEEK_API_KEY='sk-test'\n",
+            "DEEPSEEK_API_KEY"
+        ));
+        assert!(!dotenv_has_key("DEEPSEEK_API_KEY=\n", "DEEPSEEK_API_KEY"));
+        assert!(!dotenv_has_key("DEEPSEEK_API_KEY=\"\"\n", "DEEPSEEK_API_KEY"));
+        assert!(!dotenv_has_key(
+            "# DEEPSEEK_API_KEY=sk-test\n",
+            "DEEPSEEK_API_KEY"
+        ));
+        assert!(!dotenv_has_key("OTHER=sk-test\n", "DEEPSEEK_API_KEY"));
+    }
+
+    #[test]
+    fn pi_ai_api_key_env_reads_settings_route() {
+        let yaml = r#"
+llm-pi-ai:
+  providers:
+    gpt:
+      displayName: gpt
+      apiKeyEnv: OPENAI_API_KEY
+"#;
+        assert_eq!(
+            pi_ai_api_key_env_from_settings(yaml, "gpt").as_deref(),
+            Some("OPENAI_API_KEY")
+        );
+        assert_eq!(pi_ai_api_key_env_from_settings(yaml, "missing"), None);
+        assert_eq!(pi_ai_api_key_env_from_settings("{}", "gpt"), None);
+    }
+
+    #[test]
+    fn credential_status_accepts_dotenv_when_yaml_missing() {
+        let dir = std::env::temp_dir().join(format!("kivio-dsh-env-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let user_env = dir.join(".env");
+        std::fs::write(&user_env, "DEEPSEEK_API_KEY=sk-from-home\n").unwrap();
+        let (configured, writable) =
+            credential_status_with_files("DEEPSEEK_API_KEY", None, Some(&user_env), None);
+        assert!(configured);
+        assert!(writable);
+
+        let project_env = dir.join("project.env");
+        std::fs::write(&project_env, "GPT_KEY=sk-project\n").unwrap();
+        let (configured, writable) =
+            credential_status_with_files("GPT_KEY", None, None, Some(&project_env));
+        assert!(configured);
+        assert!(writable);
+
+        let credentials = dir.join(".credentials.yaml");
+        std::fs::write(&credentials, "DEEPSEEK_API_KEY: sk-yaml\n").unwrap();
+        let (configured, writable) =
+            credential_status_with_files("DEEPSEEK_API_KEY", Some(&credentials), None, None);
+        assert!(configured);
+        assert!(writable);
+
+        let (configured, _) = credential_status_with_files(
+            "MISSING_KEY",
+            Some(&credentials),
+            Some(&user_env),
+            Some(&project_env),
+        );
+        assert!(!configured);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn official_deepseek_key_ready_matches_credential_status() {
+        assert_eq!(
+            official_deepseek_key_ready(),
+            credential_status(DEFAULT_API_KEY_ENV).0
+        );
     }
 }

--- a/src-tauri/src/external_agents/dsh_profile.rs
+++ b/src-tauri/src/external_agents/dsh_profile.rs
@@ -570,6 +570,7 @@ mod tests {
         assert!(BRIDGE_SOURCE.contains("'userQuestions'"));
         assert!(BRIDGE_SOURCE.contains("'attachments'"));
         assert!(BRIDGE_SOURCE.contains("'jobs'"));
+        assert!(BRIDGE_SOURCE.contains("'subagents'"));
         assert!(BRIDGE_SOURCE.contains("saveImage"));
         assert!(BRIDGE_SOURCE.contains("session/commands"));
         assert!(BRIDGE_SOURCE.contains("session/stop-job"));

--- a/src-tauri/src/external_agents/session/dsh_jsonrpc.rs
+++ b/src-tauri/src/external_agents/session/dsh_jsonrpc.rs
@@ -188,15 +188,18 @@ impl DshJsonRpcSession {
         preset: Option<&str>,
     ) -> Result<Self, String> {
         let _profile_boot_guard = DSH_PROFILE_BOOT_LOCK.lock().await;
+        let route = resolve_model_route_for_turn(model)?;
         if crate::external_agents::overrides::active_provider("dsh").is_none()
-            && !crate::external_agents::dsh_plugins::official_deepseek_key_ready()
+            && !crate::external_agents::dsh_plugins::credentials_ready_for_provider(
+                &route.provider,
+                Some(cwd),
+            )
         {
             return Err("missing credential".to_string());
         }
         crate::external_agents::dsh_profile::ensure_profile_ready(resolved_bin, reasoning, preset)
             .await?;
 
-        let route = resolve_model_route_for_turn(model)?;
         let session_id = resume_session_id
             .map(str::trim)
             .filter(|id| !id.is_empty())

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kivio Desktop",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "identifier": "com.zmair.kivio",
   "build": {
     "beforeDevCommand": "npm run prepare:pyodide && npm run dev:ui",

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -195,7 +195,7 @@
 
 <div class="topbar">
   <button class="menu-btn" id="menuBtn" aria-label="Menu">≡</button>
-  <a class="brand" href="../index.html"><img src="../assets/logo.png" alt="" />KIVIO DESKTOP<span class="docs-tag">DOCS · v2.9.0</span></a>
+  <a class="brand" href="../index.html"><img src="../assets/logo.png" alt="" />KIVIO DESKTOP<span class="docs-tag">DOCS · v2.9.1</span></a>
   <div class="spacer"></div>
   <a class="top-link" href="../index.html">← 官网</a>
   <a class="icon-link" href="https://github.com/ZMGID/kivio" target="_blank" rel="noopener" aria-label="GitHub">
@@ -288,9 +288,9 @@
     <article data-page="install" class="hidden">
       <div class="crumb">开始</div>
       <h1>安装</h1>
-      <p class="lead">当前稳定版为 v2.9.0，从 GitHub Releases 获取对应平台安装包。</p>
+      <p class="lead">当前稳定版为 v2.9.1，从 GitHub Releases 获取对应平台安装包。</p>
       <h2 id="install-mac">macOS</h2>
-      <p>Apple Silicon 下载 <code>Kivio.Desktop_2.9.0_aarch64.dmg</code>，打开后拖入 Applications。系统要求 macOS 13 及以上（屏幕捕获基于 ScreenCaptureKit）。当前 DMG 未签名，首次启动请在 Finder 中右键 Kivio Desktop →「打开」，或执行：</p>
+      <p>Apple Silicon 下载 <code>Kivio.Desktop_2.9.1_aarch64.dmg</code>，打开后拖入 Applications。系统要求 macOS 13 及以上（屏幕捕获基于 ScreenCaptureKit）。当前 DMG 未签名，首次启动请在 Finder 中右键 Kivio Desktop →「打开」，或执行：</p>
       <pre><code>xattr -cr "/Applications/Kivio Desktop.app"</code></pre>
       <p>首次使用以下功能时，系统会请求相应的隐私权限：</p>
       <table>
@@ -302,7 +302,7 @@
       </table>
       <p>在「系统设置 → 隐私与安全性」中为 Kivio Desktop 打开对应开关即可，无需重启应用。</p>
       <h2 id="install-win">Windows</h2>
-      <p>下载并运行 <code>Kivio.Desktop_2.9.0_x64-setup.exe</code>（NSIS），支持 Windows 10/11 x64。手动启动默认打开 AI 客户端；勾选开机自启后，启动时会附带 <code>--from-autostart</code> 参数直接进入后台，不弹出窗口。</p>
+      <p>下载并运行 <code>Kivio.Desktop_2.9.1_x64-setup.exe</code>（NSIS），支持 Windows 10/11 x64。手动启动默认打开 AI 客户端；勾选开机自启后，启动时会附带 <code>--from-autostart</code> 参数直接进入后台，不弹出窗口。</p>
       <h2 id="install-update">更新</h2>
       <p>应用启动时会静默检查一次 GitHub Releases 是否有新版本（<code>autoCheckUpdate</code>，默认开启）。也可以在「设置 → 关于」手动检查；发现新版本后可直接在应用内下载安装包并启动安装。若 GitHub API 检查失败，界面会提供 Releases 页面作为手动下载兜底。</p>
     </article>
@@ -310,7 +310,7 @@
     <article data-page="quickstart" class="hidden">
       <div class="crumb">开始</div>
       <h1>快速上手</h1>
-      <p class="lead">从安装 v2.9.0 到第一轮智能体对话，再试一次屏幕工具与本地 Agent。</p>
+      <p class="lead">从安装 v2.9.1 到第一轮智能体对话，再试一次屏幕工具与本地 Agent。</p>
       <h2 id="qs-install">第一步 · 安装并启动</h2>
       <p>从 <a href="https://github.com/ZMGID/kivio/releases/latest" target="_blank" rel="noopener">GitHub Releases ↗</a> 下载最新版：macOS Apple Silicon 使用 <code>.dmg</code>，Windows x64 使用 NSIS <code>-setup.exe</code>。macOS DMG 未签名，首次启动需要右键 →「打开」。详细权限与更新说明见 <a href="#/install">安装</a>。</p>
       <h2 id="qs-key">第二步 · 完成首次引导</h2>
@@ -751,6 +751,16 @@ kivio code --no-approve -p "审查当前项目"</code></pre>
       <div class="crumb">更多</div>
       <h1>更新日志</h1>
       <p class="lead">每个版本的变化。完整发布记录见 <a href="https://github.com/ZMGID/kivio/releases" target="_blank" rel="noopener" style="border-bottom:1px solid var(--fg)">GitHub Releases ↗</a>。</p>
+      <h2 id="changelog-291">v2.9.1 · 2026-08-16</h2>
+      <ul>
+        <li><b>DeepSeek Harness</b> —— 补齐图片、附件路径、停任务（含子代理）和斜杠发现；模型图片与推理档写回已有路由；第三方供应商握手不再空转。空白机器可一键安装并填官方密钥。凭据按官方分层识别环境变量、凭据文件和 <code>.env</code>，第三方路由用各自的密钥环境变量，不再误拦。</li>
+        <li><b>外部 CLI 系统提示</b> —— 对话所属集的系统提示会注入外部 CLI，切集不再丢掉那一层人设。</li>
+        <li><b>供应商模型列表</b> —— 拉模型按协议鉴权，并解析 Gemini 原生 ListModels。</li>
+        <li><b>启动体验</b> —— 启动后可最小化到托盘；开机自启不再强行弹出聊天窗。</li>
+        <li><b>聊天</b> —— 工作台路径挪到 tools 之后，避免跨会话打穿前缀缓存。</li>
+        <li><b>发版</b> —— GitHub Actions 同时打包 Windows 与 macOS。</li>
+      </ul>
+      <p><a href="https://github.com/ZMGID/kivio/releases/tag/v2.9.1" target="_blank" rel="noopener">查看 v2.9.1 Release notes ↗</a></p>
       <h2 id="changelog-290">v2.9.0 · 2026-08-15</h2>
       <ul>
         <li><b>DeepSeek Harness</b> —— 新增 dsh 作为外部 CLI 代理：官方供应商、四档 Agent 模式、插件页、斜杠命令（已知命令高亮）、工具卡、压缩，以及 <code>/compact</code> <code>/goal</code> <code>/feedback</code>。重启或改启动配置后仍续上原生会话；顶栏显示实际模型与思考档。后台子代理显示实时进度，完成后把汇报写回父对话，和官方 web 一致。用量条不再把已排除的缓存输入减第二次。</li>

--- a/website/index.html
+++ b/website/index.html
@@ -336,7 +336,7 @@
       <a class="btn-solid" href="https://github.com/ZMGID/kivio/releases/latest" target="_blank" rel="noopener"><span data-i18n="hero.cta">下载 Kivio Desktop</span><span class="arr">↓</span></a>
       <a class="link-plain" href="https://github.com/ZMGID/kivio" target="_blank" rel="noopener"><span>GitHub</span><span class="arr">↗</span></a>
     </div>
-    <div class="hero-meta" data-i18n="hero.meta">v2.9.0 — macOS · Windows — GPL-3.0</div>
+    <div class="hero-meta" data-i18n="hero.meta">v2.9.1 — macOS · Windows — GPL-3.0</div>
   </div>
   <div class="scroll-hint">SCROLL</div>
 </section>
@@ -439,7 +439,7 @@ const I18N = {
     'hero.tagline': '屏幕所至，智能所及。',
     'hero.mission': 'Kivio Desktop 是一款开源桌面 Agentic AI 应用。智能体对话、划词翻译、屏幕取景问答 —— 使用你自己的密钥，数据留在你自己的机器。',
     'hero.cta': '下载 Kivio Desktop',
-    'hero.meta': 'v2.9.0 — macOS · Windows — GPL-3.0',
+    'hero.meta': 'v2.9.1 — macOS · Windows — GPL-3.0',
     'prod.eyebrow': '当前产品', 'prod.live': '持续构建中',
     'prod.desc': '一个完整的桌面 Agentic AI 工作台。<b>以智能体内核为中心</b>：工具循环、并行子智能体、MCP、Skills、知识库检索，包在一个安静克制的图形界面里。始于一次对话，终于一支舰队。',
     'prod.dl': '下载', 'prod.all': '全部版本',
@@ -481,7 +481,7 @@ const I18N = {
     'hero.tagline': 'Your screen, intelligent.',
     'hero.mission': 'Kivio Desktop is an open-source desktop agentic AI app. Agentic chat, instant translation, and screen capture Q&amp;A — powered by your own keys, on your own machine.',
     'hero.cta': 'Download Kivio Desktop',
-    'hero.meta': 'v2.9.0 — macOS · Windows — GPL-3.0',
+    'hero.meta': 'v2.9.1 — macOS · Windows — GPL-3.0',
     'prod.eyebrow': 'Current product', 'prod.live': 'Under active build',
     'prod.desc': 'A complete desktop agentic AI workspace. <b>Built around one agent core</b>: tool loops, parallel sub-agents, MCP, Skills, and knowledge retrieval — wrapped in a quiet, restrained GUI. It starts with one conversation, and scales to a fleet.',
     'prod.dl': 'Download', 'prod.all': 'All releases',


### PR DESCRIPTION
## Summary
- dsh connect 按本轮路由对齐官方凭据分层（环境变量 / 凭据文件 / `.env`），第三方路由不再误要求官方密钥。
- bridge 注入 `subagents`，停任务能真正打断子代理。
- 版本升到 2.9.1，并同步 README、官网与 `docs/releases/v2.9.1.md`。

## Test plan
- [ ] CI on this PR is green
- [ ] Merge to main, wait for CI on main
- [ ] Tag `v2.9.1` to start the installer workflow
- [ ] Overwrite the GitHub release body with `docs/releases/v2.9.1.md`
