### PR TITLE
fix(settings): 收窄 dsh 思考档类型，修复 CI typecheck

### DIFF
--- a/src/settings/CliProviderModal.tsx
+++ b/src/settings/CliProviderModal.tsx
@@ -1895,7 +1895,7 @@ export function CliProviderModal({
                         )}
                       </label>
                     </div>
-                    {metadata.reasoning && (
+                    {metadata.reasoning && 'thinkingLevels' in metadata && (
                       <div className="kv-native-model-efforts">
                         <span>{t.externalAgentsDshReasoningEfforts}</span>
                         <div


### PR DESCRIPTION
## Summary
- `CliProviderModal` 在 dsh 思考档 UI 访问 `metadata.thinkingLevels` 前用 `in` 收窄，修掉 OpenCode 联合类型导致的 CI typecheck 失败。

## Test plan
- [ ] CI typecheck passes
- [ ] Merge to main, then tag v2.9.1
