### PR TITLE
docs(release): 从 2.9.1 亮点里拿掉内部打包说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ Kivio Desktop 启动后会检查 GitHub Releases 的新版本（可关闭），�
 - **供应商模型列表** —— 拉模型按协议鉴权，并解析 Gemini 原生 ListModels。
 - **启动体验** —— 启动后可最小化到托盘；开机自启不再强行弹出聊天窗。
 - **聊天** —— 工作台路径挪到 tools 之后，避免跨会话打穿前缀缓存。
-- **发版** —— GitHub Actions 同时打包 Windows 与 macOS。
 
 ## v2.9.0
 
@@ -443,7 +442,6 @@ Kivio Desktop checks GitHub Releases for updates shortly after launch (can be di
 - **Provider model lists** — listing models authenticates per protocol and parses Gemini's native ListModels.
 - **Launch** — can minimize to the tray after start; launch-at-startup no longer forces the chat window open.
 - **Chat** — the workbench path moves after tools, so switching conversations no longer busts the prefix cache.
-- **Release** — GitHub Actions packages Windows and macOS in the same workflow.
 
 ## v2.9.0
 

--- a/docs/releases/v2.9.1.md
+++ b/docs/releases/v2.9.1.md
@@ -16,7 +16,6 @@
 - **供应商模型列表** —— 拉模型按协议鉴权，并解析 Gemini 原生 ListModels。
 - **启动体验** —— 启动后可最小化到托盘；开机自启不再强行弹出聊天窗。
 - **聊天** —— 工作台路径挪到 tools 之后，避免跨会话打穿前缀缓存。
-- **发版** —— GitHub Actions 同时打包 Windows 与 macOS。
 
 ## What's New
 
@@ -25,7 +24,6 @@
 - **Provider model lists** — listing models authenticates per protocol and parses Gemini's native ListModels.
 - **Launch** — can minimize to the tray after start; launch-at-startup no longer forces the chat window open.
 - **Chat** — the workbench path moves after tools, so switching conversations no longer busts the prefix cache.
-- **Release** — GitHub Actions packages Windows and macOS in the same workflow.
 
 ---
 

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -758,7 +758,6 @@ kivio code --no-approve -p "审查当前项目"</code></pre>
         <li><b>供应商模型列表</b> —— 拉模型按协议鉴权，并解析 Gemini 原生 ListModels。</li>
         <li><b>启动体验</b> —— 启动后可最小化到托盘；开机自启不再强行弹出聊天窗。</li>
         <li><b>聊天</b> —— 工作台路径挪到 tools 之后，避免跨会话打穿前缀缓存。</li>
-        <li><b>发版</b> —— GitHub Actions 同时打包 Windows 与 macOS。</li>
       </ul>
       <p><a href="https://github.com/ZMGID/kivio/releases/tag/v2.9.1" target="_blank" rel="noopener">查看 v2.9.1 Release notes ↗</a></p>
       <h2 id="changelog-290">v2.9.0 · 2026-08-15</h2>


### PR DESCRIPTION
## Summary
- 从 README、官网和 `docs/releases/v2.9.1.md` 去掉 GitHub Actions 打包那条内部说明。GitHub Release 正文已经改过。

## Test plan
- [ ] 亮点里不再出现「发版 / GitHub Actions」那条