### PR TITLE
feat(external-cli): 支持官方 Antigravity CLI 与命令结果面板

### DIFF
--- a/docs/research/antigravity-cli-adapter.md
+++ b/docs/research/antigravity-cli-adapter.md
@@ -61,6 +61,13 @@ skill names are not hardcoded into the built-in menu. Terminal-only commands ret
 an explanation without destroying the session. The live test checks reports and
 skill passthrough between ordinary turns, preserving recall, then cancel/resume.
 
+Reports persist as versioned `kivio-cli-report` JSON fences, rendered by the shared
+Markdown pipeline as command panels. Quota reports show remaining bars and local
+reset times; help/skills/agents have search and copy controls. Configuration reports
+use key/value rows. Raw output remains available in a collapsed disclosure. Exact
+legacy quota reports are also rendered as panels without rewriting stored history.
+Unknown quota formats fall back to preserved text instead of guessed percentages.
+
 ## Verification
 
 Verified on Windows with agy 1.1.26: 697 external-agent unit/regression tests,

--- a/docs/research/antigravity-cli-adapter.md
+++ b/docs/research/antigravity-cli-adapter.md
@@ -52,6 +52,17 @@ concurrently in the original working directory.
 Unit tests cover stream parsing, tool errors, soft denials, usage accounting, model
 catalog parsing, launch flags, installer routing and reconnect/retry policy.
 
+Desktop follow-up: the first in-app `agy models` probe hit its 30-second timeout;
+a forced retry through the same Tauri command returned all 14 models. The probe now
+allows 60 seconds and drops/kills its child on timeout. The picker displays the
+backend error instead of only a generic fallback notice. This mitigates slow probes;
+the CLI's intermittent delay has not been traced to an internal cause.
+
+For debug builds, write a request with `prompt: ""`, `probeModels: true`,
+`externalAgentId: "antigravity"`, and an optional `conversationId` to
+`<app_data>/chat_probe/request.json`. The watcher runs the exact model-picker command
+with cache bypass and writes `models-result.json`, without creating a chat turn.
+
 The opt-in `live_antigravity_multiturn_tools_cancel_and_resume` Rust test uses an
 isolated temporary workspace and a signed-in `agy`. It checks multi-turn recall,
 file-tool events, cancellation, process replacement and native conversation recovery:

--- a/docs/research/antigravity-cli-adapter.md
+++ b/docs/research/antigravity-cli-adapter.md
@@ -38,8 +38,28 @@ Permissions inherit the CLI configuration unless the user explicitly selects ano
 mode. Sign-in happens through an interactive `agy` terminal session.
 
 The input stream supports text only; image attachments use the existing file-path
-fallback. Runtime steering, native follow-up injection, approval RPCs, slash commands
+fallback. Runtime steering, native follow-up injection, approval RPCs
 and native-history import are not advertised by this adapter.
+
+## Slash commands
+
+The command menu is maintained in Kivio and ships with Kivio updates. Opening `/`
+returns the built-in catalog immediately without CLI discovery, binary resolution,
+or network access. `/help` describes this adapted catalog. It is not a copy of the
+full interactive-terminal command list.
+
+`/agents`, `/changelog`, `/config` (`/settings`), `/credits`, `/effort`, `/hooks`,
+`/model`, `/permissions`, `/skills`, and `/usage` (`/quota`) run as standalone
+`agy -p` reports. Stream flags and the conversation binding are removed; active
+model/effort flags are retained. Configuration reports are read-only: model, effort,
+and permission changes use the existing Kivio controls. Report errors do not close
+the native session; cancellation terminates the report subprocess.
+
+User-invoked `/skills` lists the CLI's currently loaded skills. `/skill-name args`
+passes through the native NDJSON session for agy to expand. Workspace-dependent
+skill names are not hardcoded into the built-in menu. Terminal-only commands return
+an explanation without destroying the session. The live test checks reports and
+skill passthrough between ordinary turns, preserving recall, then cancel/resume.
 
 ## Verification
 

--- a/docs/research/antigravity-cli-adapter.md
+++ b/docs/research/antigravity-cli-adapter.md
@@ -1,0 +1,66 @@
+# Antigravity CLI adapter
+
+The external agent id is `antigravity`; the executable is Google's official `agy`.
+This integration does not use the similarly named third-party IDE bridge.
+
+## Protocol and lifecycle
+
+- Launch with `--input-format stream-json --output-format stream-json`.
+- Read `init.conversation_id` before registering a live session. Persist the actual
+  native id and resume only with `--conversation <id>`. Reject a mismatched id.
+- Send each prompt as a `user` event. One `result` finishes a turn, not the process.
+- Changes to model, effort, permissions, attached directories or managed environment
+  variables restart the process while retaining the native conversation binding.
+- Cancel terminates the process tree. The next turn resumes the persisted id.
+- A failed in-flight turn is not automatically replayed: agy has no request-id based
+  acknowledgement/deduplication to prevent repeating tool side effects.
+- Native session loss is surfaced as an error rather than silently starting over.
+
+## Observations from agy 1.1.26 on Windows
+
+- `init` arrives before any prompt is sent.
+- Response chunks use `text_delta`; the final response repeats the text.
+- Tool transitions include `ACTIVE`, `DONE` and `ERROR`. Tool errors must close cards.
+- A denied tool can end in `SUCCESS` with an empty response and `denied_actions`.
+  The adapter surfaces this as an actionable permission error.
+- Per-step usage is local to that step; `result.usage` is cumulative across the
+  conversation. Use per-step totals for the first resumed turn as well.
+- Observed usage: input 5969, output 554, cache read 8132, native total 6523.
+  Cache is separate from input, and thinking is already included in output.
+  Kivio's context total therefore includes cache without adding thinking twice.
+- `agy models` returns tab-separated model ids and labels.
+
+## Supported boundary
+
+Includes native installation/update discovery, model and effort selection,
+permission modes, streaming text, tool cards, usage, multi-turn sessions and resume.
+Permissions inherit the CLI configuration unless the user explicitly selects another
+mode. Sign-in happens through an interactive `agy` terminal session.
+
+The input stream supports text only; image attachments use the existing file-path
+fallback. Runtime steering, native follow-up injection, approval RPCs, slash commands
+and native-history import are not advertised by this adapter.
+
+## Verification
+
+Verified on Windows with agy 1.1.26: 697 external-agent unit/regression tests,
+56 relevant frontend tests, TypeScript checking, and the live multi-turn/tool/cancel/
+resume test all passed. Rust and final frontend checks ran in an isolated worktree
+containing this adapter only, because unrelated plugin changes were being edited
+concurrently in the original working directory.
+
+Unit tests cover stream parsing, tool errors, soft denials, usage accounting, model
+catalog parsing, launch flags, installer routing and reconnect/retry policy.
+
+The opt-in `live_antigravity_multiturn_tools_cancel_and_resume` Rust test uses an
+isolated temporary workspace and a signed-in `agy`. It checks multi-turn recall,
+file-tool events, cancellation, process replacement and native conversation recovery:
+
+```powershell
+cargo test --manifest-path src-tauri/Cargo.toml --lib antigravity
+cargo test --manifest-path src-tauri/Cargo.toml --lib live_antigravity_multiturn_tools_cancel_and_resume -- --ignored --nocapture
+```
+
+References: [official headless protocol](https://antigravity.google/docs/cli/headless/),
+[installation](https://antigravity.google/docs/cli/install/),
+[official releases](https://github.com/google-antigravity/antigravity-cli/releases).

--- a/src-tauri/src/chat/probe.rs
+++ b/src-tauri/src/chat/probe.rs
@@ -36,6 +36,10 @@ const POLL_INTERVAL: Duration = Duration::from_millis(700);
 pub(crate) struct ProbeRequest {
     #[serde(default)]
     pub(crate) id: Option<String>,
+    /// Read-only model probe through the same command used by the model picker.
+    /// Writes models-result.json instead of creating a chat turn.
+    #[serde(default)]
+    pub(crate) probe_models: bool,
     pub(crate) prompt: String,
     #[serde(default)]
     pub(crate) provider: Option<String>,
@@ -259,6 +263,26 @@ pub async fn run_probe_watcher(app: AppHandle) {
             }
         };
 
+        if req.probe_models {
+            let result = crate::external_agents::commands::chat_detect_external_agent_models(
+                app.clone(),
+                app.state::<AppState>(),
+                req.external_agent_id.clone().unwrap_or_default(),
+                req.conversation_id.clone(),
+                Some(true),
+            )
+            .await;
+            let value = match result {
+                Ok(payload) => serde_json::json!({"id":req.id,"payload":payload}),
+                Err(error) => serde_json::json!({"id":req.id,"error":error}),
+            };
+            let _ = crate::chat::storage::atomic_write(
+                &dir.join("models-result.json"),
+                &value.to_string(),
+                "model probe",
+            );
+            continue;
+        }
         eprintln!("[chat-probe] running: {:?}", req.prompt);
         let result = handle_probe_request(&app, req).await;
         write_result(&dir, &result);
@@ -500,19 +524,21 @@ mod tests {
         // 新探点的缺省必须是「什么都不做」：取消不触发，上下文状态不额外计算。
         assert!(req.cancel_after_ms.is_none());
         assert!(!req.compute_context_stats);
+        assert!(!req.probe_models);
         assert!(req.external_model.is_none() && req.external_sandbox.is_none());
     }
 
     #[test]
     fn probe_request_parses_the_new_probes() {
         let req: ProbeRequest = serde_json::from_str(
-            r#"{"prompt":"hi","cancelAfterMs":1500,"computeContextStats":true,
+            r#"{"prompt":"hi","cancelAfterMs":1500,"computeContextStats":true,"probeModels":true,
                 "externalAgentId":"claude","externalModel":"sonnet",
                 "externalReasoning":"high","externalSandbox":"bypassPermissions"}"#,
         )
         .expect("parse");
         assert_eq!(req.cancel_after_ms, Some(1500));
         assert!(req.compute_context_stats);
+        assert!(req.probe_models);
         assert_eq!(req.external_agent_id.as_deref(), Some("claude"));
         assert_eq!(req.external_model.as_deref(), Some("sonnet"));
         assert_eq!(req.external_reasoning.as_deref(), Some("high"));

--- a/src-tauri/src/external_agents/antigravity_slash.rs
+++ b/src-tauri/src/external_agents/antigravity_slash.rs
@@ -1,0 +1,221 @@
+//! Kivio-maintained command catalog, verified with agy 1.1.26. No runtime discovery.
+//! Reports cannot enter the NDJSON stream: agy emits ERROR and exits. Run them
+//! separately without a conversation binding; native skill expansion stays in-stream.
+use std::path::Path;
+use std::time::Duration;
+
+use crate::external_agents::spawn::{cli_command, fold_stderr};
+use crate::external_agents::types::ExternalCliSlashCommand;
+use crate::proc::NoConsoleWindow;
+
+pub fn is_report(name: &str) -> bool {
+    matches!(
+        name,
+        "help"
+            | "agents"
+            | "changelog"
+            | "config"
+            | "settings"
+            | "credits"
+            | "effort"
+            | "hooks"
+            | "model"
+            | "permissions"
+            | "skills"
+            | "usage"
+            | "quota"
+    )
+}
+
+pub fn is_terminal_only(name: &str) -> bool {
+    matches!(
+        name,
+        "add-dir"
+            | "artifact"
+            | "btw"
+            | "clear"
+            | "new"
+            | "context"
+            | "copy"
+            | "diff"
+            | "exit"
+            | "quit"
+            | "fast"
+            | "feedback"
+            | "fork"
+            | "branch"
+            | "keybindings"
+            | "logout"
+            | "mcp"
+            | "open"
+            | "planning"
+            | "rename"
+            | "resume"
+            | "switch"
+            | "conversation"
+            | "rewind"
+            | "undo"
+            | "statusline"
+            | "tasks"
+            | "title"
+            | "voice"
+            | "record"
+    )
+}
+
+pub fn command_name(prompt: &str) -> Option<&str> {
+    prompt
+        .trim_start()
+        .strip_prefix('/')?
+        .split_whitespace()
+        .next()
+}
+
+/// Keep the active model/effort/mode flags but never pass the stream protocol
+/// or conversation id to a report process. Reports must not alter native history.
+pub fn report_args(args: &[String], prompt: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        if matches!(
+            args[index].as_str(),
+            "--input-format" | "--output-format" | "--conversation"
+        ) {
+            index += 2;
+        } else {
+            out.push(args[index].clone());
+            index += 1;
+        }
+    }
+    out.extend(["-p".into(), prompt.trim().into()]);
+    out
+}
+
+pub async fn report(
+    bin: &Path,
+    cwd: &Path,
+    args: &[String],
+    prompt: &str,
+) -> Result<String, String> {
+    let output = tokio::time::timeout(
+        Duration::from_secs(60),
+        cli_command(bin)
+            .args(report_args(args, prompt))
+            .current_dir(cwd)
+            .no_console_window()
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .map_err(|_| "Antigravity 命令超时（60s）".to_string())?
+    .map_err(|e| format!("Antigravity 命令启动失败：{e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        return Err(fold_stderr(
+            format!(
+                "Antigravity 命令退出码：{}\n{stdout}",
+                output.status.code().unwrap_or(-1)
+            ),
+            &stderr,
+        ));
+    }
+    Ok(if stdout.is_empty() {
+        stderr.trim().to_string()
+    } else {
+        stdout
+    })
+}
+
+/// This catalog ships with Kivio. Opening `/` never starts agy or fetches a catalog.
+pub fn builtin_commands() -> Vec<ExternalCliSlashCommand> {
+    [
+        ("help", "查看 Kivio 已适配的 Antigravity 命令"),
+        ("agents", "列出可用的自定义 Agent"),
+        ("changelog", "查看 Antigravity CLI 更新记录"),
+        ("config", "查看 CLI 配置（只读）"),
+        ("credits", "查看剩余 AI credits"),
+        ("effort", "查看当前推理强度；切换请使用顶部强度菜单"),
+        ("hooks", "查看 CLI hooks 配置（只读）"),
+        ("model", "查看当前模型；切换请使用顶部模型菜单"),
+        ("permissions", "查看 CLI 权限配置（只读）"),
+        ("skills", "列出原生技能；使用 /技能名 任务 执行"),
+        ("usage", "查看模型配额（别名 /quota）"),
+    ]
+    .into_iter()
+    .map(|(name, description)| ExternalCliSlashCommand {
+        name: name.into(),
+        slash: format!("/{name}"),
+        description: Some(description.into()),
+        argument_hint: None,
+    })
+    .collect()
+}
+
+pub fn help_text() -> String {
+    let mut text = builtin_commands()
+        .into_iter()
+        .map(|command| {
+            format!(
+                "{} — {}",
+                command.slash,
+                command.description.unwrap_or_default()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    text.push_str("\n\n技能：先用 /skills 查看 CLI 已加载的技能，再输入 /技能名 任务。配置查询不修改当前会话设置；终端专属命令请在 agy 中使用。");
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shipped_catalog_only_advertises_implemented_reports() {
+        let commands = builtin_commands();
+        let names: std::collections::HashSet<_> =
+            commands.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names.len(), commands.len());
+        assert!(commands
+            .iter()
+            .all(|c| is_report(&c.name) && !is_terminal_only(&c.name)));
+        assert!(help_text().contains("/usage"));
+        assert!(help_text().contains("/技能名"));
+        assert_eq!(command_name("  /usage  "), Some("usage"));
+        assert_eq!(command_name("hello /usage"), None);
+    }
+
+    #[test]
+    fn report_launch_keeps_active_settings_without_stream_or_session() {
+        let args = [
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--conversation",
+            "native-id",
+            "--model",
+            "custom-model",
+            "--effort",
+            "high",
+            "--add-dir",
+            "C:\\my files",
+        ]
+        .map(str::to_string);
+        assert_eq!(
+            report_args(&args, "/model"),
+            [
+                "--model",
+                "custom-model",
+                "--effort",
+                "high",
+                "--add-dir",
+                "C:\\my files",
+                "-p",
+                "/model"
+            ]
+        );
+    }
+}

--- a/src-tauri/src/external_agents/antigravity_slash.rs
+++ b/src-tauri/src/external_agents/antigravity_slash.rs
@@ -168,9 +168,35 @@ pub fn help_text() -> String {
     text
 }
 
+/// A versioned, inert payload rendered as a command panel by Kivio. Keep the raw
+/// output for copying and for unknown future CLI formats; never embed executable HTML.
+pub fn render_report(command: &str, output: &str) -> String {
+    let payload = serde_json::json!({
+        "version": 1, "agent": "antigravity", "command": command, "output": output,
+    })
+    .to_string()
+    .replace('`', "\\u0060");
+    format!("```kivio-cli-report\n{payload}\n```")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rich_report_roundtrips_raw_output_without_breaking_the_fence() {
+        let raw = "skill\tDescription\n```html\n<script>noop</script>\n```";
+        let rendered = render_report("skills", raw);
+        let body = rendered
+            .strip_prefix("```kivio-cli-report\n")
+            .unwrap()
+            .strip_suffix("\n```")
+            .unwrap();
+        assert!(!body.contains('`'));
+        let payload: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert_eq!(payload["output"], raw);
+        assert_eq!(payload["version"], 1);
+    }
 
     #[test]
     fn shipped_catalog_only_advertises_implemented_reports() {

--- a/src-tauri/src/external_agents/defs/antigravity.rs
+++ b/src-tauri/src/external_agents/defs/antigravity.rs
@@ -60,7 +60,7 @@ pub const ANTIGRAVITY_AGENT_DEF: RuntimeAgentDef = RuntimeAgentDef {
     models_from_stderr: false,
     model_probe: None,
     model_probe_args: None,
-    slash_strategy: SlashStrategy::None,
+    slash_strategy: SlashStrategy::Antigravity,
     env: &[],
     max_prompt_arg_bytes: None,
     prompt_via_stdin: true,

--- a/src-tauri/src/external_agents/defs/antigravity.rs
+++ b/src-tauri/src/external_agents/defs/antigravity.rs
@@ -1,0 +1,110 @@
+use super::super::types::{
+    PromptInputFormat, RuntimeAgentDef, RuntimeBuildOptions, RuntimeContext, SlashStrategy,
+    StreamFormat,
+};
+
+pub fn build_antigravity_args(
+    ctx: &RuntimeContext,
+    options: &RuntimeBuildOptions,
+    _prompt: Option<&str>,
+) -> Vec<String> {
+    let mut args = vec![
+        "--input-format".into(),
+        "stream-json".into(),
+        "--output-format".into(),
+        "stream-json".into(),
+    ];
+    // Resume is supplied by the persisted live handle in connect(), never --continue.
+    // agy allocates its own conversation id; a Kivio-generated UUID is not a new-session flag.
+    for (flag, value) in [
+        ("--model", &options.model),
+        ("--effort", &options.reasoning),
+    ] {
+        if let Some(value) = value
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty() && *v != "default")
+        {
+            args.extend([flag.into(), value.into()]);
+        }
+    }
+    match options.sandbox.as_deref() {
+        Some(mode @ ("plan" | "accept-edits")) => args.extend(["--mode".into(), mode.into()]),
+        Some("sandbox") => args.push("--sandbox".into()),
+        Some("always-proceed") => args.push("--dangerously-skip-permissions".into()),
+        _ => {} // Inherit native permissions; do not silently bypass them.
+    }
+    for dir in &ctx.extra_allowed_dirs {
+        args.extend(["--add-dir".into(), dir.clone()]);
+    }
+    args
+}
+
+pub const ANTIGRAVITY_AGENT_DEF: RuntimeAgentDef = RuntimeAgentDef {
+    id: "antigravity",
+    name: "Antigravity CLI",
+    bin: "agy",
+    fallback_bins: &[],
+    version_args: &["--version"],
+    auth_probe_args: None,
+    fallback_models: &[],
+    reasoning_options: &[
+        ("default", "Default"),
+        ("low", "Low"),
+        ("medium", "Medium"),
+        ("high", "High"),
+    ],
+    list_models_args: Some(&["models"]),
+    list_models_timeout_secs: Some(30),
+    models_from_stderr: false,
+    model_probe: None,
+    model_probe_args: None,
+    slash_strategy: SlashStrategy::None,
+    env: &[],
+    max_prompt_arg_bytes: None,
+    prompt_via_stdin: true,
+    prompt_input_format: PromptInputFormat::Text,
+    stream_format: StreamFormat::AntigravityStreamJson,
+    resumes_session_via_cli: true,
+    supports_native_image: false,
+    supports_steering: false,
+    supports_follow_up: false,
+    image_mime_whitelist: &[],
+    build_args: build_antigravity_args,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_flags_preserve_paths_and_never_invent_session_ids_or_permissions() {
+        let ctx = RuntimeContext {
+            extra_allowed_dirs: vec![r"C:\my project".into()],
+            resume_session_id: Some("old".into()),
+            new_session_id: Some("new".into()),
+            include_partial_messages: true,
+        };
+        let mut options = RuntimeBuildOptions {
+            model: Some("my-model".into()),
+            reasoning: Some("high".into()),
+            sandbox: None,
+        };
+        let args = build_antigravity_args(&ctx, &options, Some("must go to stdin"));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["--add-dir", r"C:\my project"]));
+        assert!(args.windows(2).any(|w| w == ["--model", "my-model"]));
+        assert!(!args.iter().any(|v| [
+            "old",
+            "new",
+            "--continue",
+            "--dangerously-skip-permissions",
+            "must go to stdin"
+        ]
+        .contains(&v.as_str())));
+        options.sandbox = Some("always-proceed".into());
+        assert!(build_antigravity_args(&ctx, &options, None)
+            .contains(&"--dangerously-skip-permissions".into()));
+    }
+}

--- a/src-tauri/src/external_agents/defs/antigravity.rs
+++ b/src-tauri/src/external_agents/defs/antigravity.rs
@@ -55,7 +55,8 @@ pub const ANTIGRAVITY_AGENT_DEF: RuntimeAgentDef = RuntimeAgentDef {
         ("high", "High"),
     ],
     list_models_args: Some(&["models"]),
-    list_models_timeout_secs: Some(30),
+    // Fetches the remote catalog; the desktop's first probe can exceed 30s.
+    list_models_timeout_secs: Some(60),
     models_from_stderr: false,
     model_probe: None,
     model_probe_args: None,

--- a/src-tauri/src/external_agents/defs/mod.rs
+++ b/src-tauri/src/external_agents/defs/mod.rs
@@ -1,4 +1,5 @@
 pub mod acp;
+pub mod antigravity;
 pub mod claude;
 pub mod codex;
 pub mod dsh;

--- a/src-tauri/src/external_agents/detection.rs
+++ b/src-tauri/src/external_agents/detection.rs
@@ -191,6 +191,7 @@ pub async fn detect_agent_models(def: &RuntimeAgentDef, cwd: &Path) -> AgentMode
             }
         }
         Err(err) => {
+            eprintln!("[external-agent] {} model probe failed: {err}", def.id);
             let models = fallback_models_from_pairs(def.fallback_models);
             // codex fallback：给每个真实模型挂上静态 effort，前端换模型时仍有档位可选。
             let reasoning_by_model = if def.id == "codex" {
@@ -1224,6 +1225,7 @@ async fn probe_models(
             .args(args)
             .current_dir(cwd)
             .no_console_window()
+            .kill_on_drop(true)
             .output(),
     )
     .await

--- a/src-tauri/src/external_agents/detection.rs
+++ b/src-tauri/src/external_agents/detection.rs
@@ -1018,6 +1018,13 @@ pub async fn detect_single_agent(def: &RuntimeAgentDef, cwd: &Path) -> DetectedA
 /// Agents without a meaningful sandbox flag return an empty list (no capsule shown).
 pub fn sandbox_options_for(agent_id: &str) -> Vec<RuntimeModelOption> {
     let pairs: &[(&str, &str)] = match agent_id {
+        "antigravity" => &[
+            ("default", "遵循 CLI 配置"),
+            ("plan", "计划"),
+            ("accept-edits", "接受编辑"),
+            ("sandbox", "沙箱"),
+            ("always-proceed", "完全放行"),
+        ],
         "claude" => &[
             ("plan", "计划 (只读)"),
             // `default` 档 = 写文件 / 跑命令前弹卡片问用户（走 stdio 控制通道的
@@ -1424,6 +1431,27 @@ fn parse_models_list(agent_id: &str, stdout: &str) -> Option<Vec<RuntimeModelOpt
     let mut out = vec![default_model_option()];
     // 曾是多 CLI 的 match（kimi `provider list --json` 分支随 kimi 迁 ACP 删除）；现在只剩
     // codex 一家还走文本 list-models 探测。
+    if agent_id == "antigravity" {
+        let mut seen = HashSet::new();
+        for line in trimmed.lines() {
+            let Some((id, label)) = line.split_once('\t') else {
+                continue;
+            };
+            let (id, label) = (id.trim(), label.trim());
+            if id.is_empty()
+                || label.is_empty()
+                || id.chars().any(char::is_whitespace)
+                || !seen.insert(id.to_string())
+            {
+                continue;
+            }
+            out.push(RuntimeModelOption {
+                id: id.into(),
+                label: label.into(),
+                context_window_tokens: None,
+            });
+        }
+    }
     if agent_id == "codex" {
         if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
             if let Some(models) = value.get("models").and_then(|v| v.as_array()) {
@@ -1461,6 +1489,14 @@ fn parse_models_list(agent_id: &str, stdout: &str) -> Option<Vec<RuntimeModelOpt
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn antigravity_models_parse_tab_separated_catalog_not_log_lines() {
+        let models = parse_models_list("antigravity", "Fetching available models...\nmy-model\tMy Model\nmy-model\tDuplicate\nother\tOther Model\n").unwrap();
+        assert_eq!(models.len(), 3);
+        assert_eq!(models[1].id, "my-model");
+        assert_eq!(models[1].label, "My Model");
+        assert!(parse_models_list("antigravity", "Authentication required").is_none());
+    }
 
     #[tokio::test]
     #[ignore = "requires live pi CLI on PATH"]

--- a/src-tauri/src/external_agents/errors.rs
+++ b/src-tauri/src/external_agents/errors.rs
@@ -65,6 +65,7 @@ fn agent_login_hint(agent_id: &str) -> (&'static str, &'static str) {
         "cursor-agent" => ("Cursor Agent", "cursor-agent login"),
         "opencode" => ("OpenCode", "opencode auth login"),
         "gemini" => ("Gemini CLI", "gemini"),
+        "antigravity" => ("Antigravity CLI", "agy"),
         "kimi" => ("Kimi CLI", "kimi"),
         "pi" => ("Pi", "pi"),
         "hermes" => ("Hermes", "hermes"),

--- a/src-tauri/src/external_agents/installer.rs
+++ b/src-tauri/src/external_agents/installer.rs
@@ -38,6 +38,16 @@ struct InstallSpec {
 
 fn install_spec(agent_id: &str) -> Option<InstallSpec> {
     let spec = match agent_id {
+        "antigravity" => InstallSpec {
+            npm_package: None,
+            npm_install_args: &[],
+            pypi_package: None,
+            script_unix: Some("curl -fsSL https://antigravity.google/cli/install.sh | bash"),
+            script_windows: Some("irm https://antigravity.google/cli/install.ps1 | iex"),
+            update_args: Some(&["update"]),
+            docs: "https://antigravity.google/docs/cli/install/",
+            config_dir: Some(".gemini/antigravity-cli"),
+        },
         "claude" => InstallSpec {
             npm_package: Some("@anthropic-ai/claude-code"),
             npm_install_args: &[],
@@ -876,6 +886,22 @@ async fn latest_version(http: &reqwest::Client, spec: &InstallSpec) -> Option<St
     }
 }
 
+async fn antigravity_latest_version(http: &reqwest::Client) -> Option<String> {
+    let value: serde_json::Value = http
+        .get("https://api.github.com/repos/google-antigravity/antigravity-cli/releases/latest")
+        .header(reqwest::header::USER_AGENT, "Kivio")
+        .timeout(Duration::from_secs(8))
+        .send()
+        .await
+        .ok()?
+        .error_for_status()
+        .ok()?
+        .json()
+        .await
+        .ok()?;
+    extract_semver(value.get("tag_name")?.as_str()?)
+}
+
 /// `--version` 输出里抓语义化版本号：CLI 们的首行格式各不相同
 /// （`2.1.207 (Claude Code)` / `codex-cli 0.146.0` / 裸 `0.53.1` / `0.1.0-rc.7`）。
 /// 保留 prerelease（dsh 目前全是 rc），丢掉 `+build` metadata。
@@ -1056,7 +1082,11 @@ pub async fn chat_external_cli_install_info(
         .and_then(crate::external_agents::spawn::cached_cli_version)
         .as_deref()
         .and_then(extract_semver);
-    let latest_version = latest_version(&state.http, &spec).await;
+    let latest_version = if agent_id == "antigravity" {
+        antigravity_latest_version(&state.http).await
+    } else {
+        latest_version(&state.http, &spec).await
+    };
     let update_available = match (&local_version, &latest_version) {
         (Some(local), Some(latest)) => version_is_newer(local, latest),
         _ => false,
@@ -1283,6 +1313,21 @@ fn open_path(path: &Path) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn antigravity_uses_official_native_installers_and_self_update() {
+        let spec = install_spec("antigravity").unwrap();
+        assert!(spec.npm_package.is_none());
+        assert!(install_plan(&spec, HostPlatform::Unix)
+            .unwrap()
+            .display
+            .contains("https://antigravity.google/cli/install.sh"));
+        assert!(install_plan(&spec, HostPlatform::Windows)
+            .unwrap()
+            .display
+            .contains("https://antigravity.google/cli/install.ps1"));
+        assert_eq!(spec.update_args, Some(&["update"][..]));
+        assert_eq!(spec.config_dir, Some(".gemini/antigravity-cli"));
+    }
 
     #[test]
     fn extract_semver_handles_each_cli_version_line() {

--- a/src-tauri/src/external_agents/mod.rs
+++ b/src-tauri/src/external_agents/mod.rs
@@ -1,4 +1,5 @@
 pub mod ask_user;
+pub mod antigravity_slash;
 pub mod attachments;
 pub mod cc_switch;
 pub mod claude_todo;

--- a/src-tauri/src/external_agents/registry.rs
+++ b/src-tauri/src/external_agents/registry.rs
@@ -1,4 +1,4 @@
-use crate::external_agents::defs::{acp, claude, codex, dsh, grok, pi};
+use crate::external_agents::defs::{acp, antigravity, claude, codex, dsh, grok, pi};
 use crate::external_agents::types::RuntimeAgentDef;
 
 pub const AGENT_DEFS: &[RuntimeAgentDef] = &[
@@ -12,6 +12,7 @@ pub const AGENT_DEFS: &[RuntimeAgentDef] = &[
     acp::HERMES_AGENT_DEF,
     grok::GROK_AGENT_DEF,
     dsh::DSH_AGENT_DEF,
+    antigravity::ANTIGRAVITY_AGENT_DEF,
 ];
 
 pub fn get_agent_def(id: &str) -> Option<&'static RuntimeAgentDef> {
@@ -23,8 +24,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn registry_has_ten_agents() {
-        assert_eq!(AGENT_DEFS.len(), 10);
+    fn registry_has_eleven_agents() {
+        assert_eq!(AGENT_DEFS.len(), 11);
+        assert!(get_agent_def("antigravity").is_some());
         assert!(get_agent_def("claude").is_some());
         assert!(get_agent_def("opencode").is_some());
         assert!(get_agent_def("pi").is_some());

--- a/src-tauri/src/external_agents/run.rs
+++ b/src-tauri/src/external_agents/run.rs
@@ -322,7 +322,11 @@ pub async fn run_external_cli_reply(
             .filter(|path| !path.trim().is_empty())
             .collect(),
     );
-    let additional_dirs_key = additional_cli_dirs.join("\n");
+    let additional_dirs_key = if agent_id == "antigravity" {
+        extra_dirs.join("\n")
+    } else {
+        additional_cli_dirs.join("\n")
+    };
     let runtime_ctx = RuntimeContext {
         extra_allowed_dirs: extra_dirs,
         resume_session_id: resume_ctx.resume_session_id.clone(),
@@ -402,6 +406,7 @@ pub async fn run_external_cli_reply(
             | StreamFormat::AcpJsonRpc
             | StreamFormat::DshJsonRpc
             | StreamFormat::PiRpc
+            | StreamFormat::AntigravityStreamJson
     );
     let mut spawned_opt = if persistent {
         None
@@ -692,10 +697,13 @@ pub async fn run_external_cli_reply(
         }
     }
 
-    let actual_native_session_id = matches!(def.stream_format, StreamFormat::PiRpc)
-        .then(|| crate::external_agents::session::load_live_handle(app, &conversation_id))
-        .flatten()
-        .map(|handle| handle.native_id);
+    let actual_native_session_id = matches!(
+        def.stream_format,
+        StreamFormat::PiRpc | StreamFormat::AntigravityStreamJson
+    )
+    .then(|| crate::external_agents::session::load_live_handle(app, &conversation_id))
+    .flatten()
+    .map(|handle| handle.native_id);
     persist_delivered_session(
         app,
         &conversation_id,
@@ -1283,6 +1291,20 @@ fn launch_config_for_turn(
             instructions: None,
         };
     }
+    if matches!(protocol, StreamFormat::AntigravityStreamJson) {
+        let env: std::collections::BTreeMap<_, _> =
+            crate::external_agents::overrides::env_for("antigravity")
+                .into_iter()
+                .collect();
+        let env_hash = crate::external_agents::session::stable_prompt_hash(
+            &serde_json::to_string(&env).unwrap_or_default(),
+        );
+        return LaunchConfig {
+            flags: serde_json::json!([model, reasoning, sandbox, additional_dirs_key, env_hash])
+                .to_string(),
+            instructions: None,
+        };
+    }
     if matches!(protocol, StreamFormat::PiRpc) {
         return LaunchConfig::for_pi(model, reasoning);
     }
@@ -1351,9 +1373,10 @@ fn persistent_turn_prompt<'a>(
     latest_user_message: &'a str,
 ) -> &'a str {
     match protocol {
-        StreamFormat::ClaudeStreamJson | StreamFormat::DshJsonRpc | StreamFormat::PiRpc => {
-            composed_prompt
-        }
+        StreamFormat::ClaudeStreamJson
+        | StreamFormat::DshJsonRpc
+        | StreamFormat::PiRpc
+        | StreamFormat::AntigravityStreamJson => composed_prompt,
         _ => latest_user_message,
     }
 }
@@ -1432,6 +1455,11 @@ fn persistent_failure_action(
             PersistentFailureAction::ReconnectWithoutResume
         };
     }
+    // agy has no request ids or prompt acknowledgement. Replaying a failed in-flight
+    // turn could execute tools twice. Preserve the binding and let the user retry.
+    if agent_id == "antigravity" {
+        return PersistentFailureAction::Fatal;
+    }
     // Auth is never auto-retried (a doomed retry could trigger a login storm).
     if crate::external_agents::errors::is_auth_error(err, agent_id) {
         return PersistentFailureAction::Fatal;
@@ -1465,7 +1493,7 @@ fn is_missing_resume_target(err: &str, agent_id: &str) -> bool {
         Some(StreamFormat::AcpJsonRpc) => {
             crate::external_agents::session::acp::is_missing_acp_session_error(err)
         }
-        None => false,
+        Some(StreamFormat::AntigravityStreamJson) | None => false,
     }
 }
 
@@ -1971,6 +1999,7 @@ fn persistent_protocol_tag(protocol: StreamFormat) -> &'static str {
         StreamFormat::AcpJsonRpc => "acp_json_rpc",
         StreamFormat::PiRpc => "pi_rpc",
         StreamFormat::DshJsonRpc => "dsh_json_rpc",
+        StreamFormat::AntigravityStreamJson => "antigravity_stream_json",
     }
 }
 
@@ -2409,6 +2438,22 @@ async fn connect_persistent_session(
     };
 
     match protocol {
+        StreamFormat::AntigravityStreamJson => {
+            use crate::external_agents::session::antigravity::{
+                spawn_antigravity_session_actor, AntigravitySession,
+            };
+            let session =
+                AntigravitySession::connect(resolved_bin, args, cwd, resume_native.as_deref())
+                    .await?;
+            let native_id = session.session_id().to_string();
+            let child_pid = session.child_pid();
+            Ok(PersistentConnection {
+                control: spawn_antigravity_session_actor(session),
+                native_id,
+                resumed: resume_native.is_some(),
+                child_pid,
+            })
+        }
         StreamFormat::ClaudeStreamJson => {
             // claude 的会话 id 走**启动参数**，不像 codex / ACP 在握手 RPC 里传 ——
             // 所以这里要看/改 argv 而不是传参。
@@ -3390,6 +3435,47 @@ fn truncate_for_preview(value: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn antigravity_preserves_turn_context_and_restarts_for_launch_changes() {
+        let protocol = StreamFormat::AntigravityStreamJson;
+        let original =
+            launch_config_for_turn(protocol, Some("a"), Some("low"), None, None, None, "dir");
+        for (model, effort, sandbox, dirs) in [
+            (Some("b"), Some("low"), None, "dir"),
+            (Some("a"), Some("high"), None, "dir"),
+            (Some("a"), Some("low"), Some("plan"), "dir"),
+            (Some("a"), Some("low"), None, "new-dir"),
+        ] {
+            assert!(!original.accepts(&launch_config_for_turn(
+                protocol, model, effort, sandbox, None, None, dirs
+            )));
+        }
+        assert_eq!(
+            persistent_turn_prompt(protocol, "skill + attachment + message", "message"),
+            "skill + attachment + message"
+        );
+        assert!(!cancel_keeps_live_session("cancelled", protocol));
+        assert_eq!(
+            persistent_failure_action(
+                "EOF after tool execution",
+                "antigravity",
+                false,
+                false,
+                false
+            ),
+            PersistentFailureAction::Fatal
+        );
+        assert_eq!(
+            persistent_failure_action(
+                crate::external_agents::session::live::CANCELLED_SESSION_LOST,
+                "antigravity",
+                false,
+                false,
+                false
+            ),
+            PersistentFailureAction::Cancelled
+        );
+    }
 
     /// 协议层自报的失败必须能到出口——修复前这里只打了一条日志，于是
     /// 「CLI 明确说本轮失败了」被整个吞掉（claude 未登录 ⇒ 空气泡 + 零提示）。

--- a/src-tauri/src/external_agents/session/antigravity.rs
+++ b/src-tauri/src/external_agents/session/antigravity.rs
@@ -1,0 +1,733 @@
+//! Official agy NDJSON protocol (verified with 1.1.26).
+//! https://antigravity.google/docs/cli/headless/
+//! One init per process, one result per turn. No control RPCs or native image blocks.
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+
+use crate::chat::model::ModelUsage;
+use crate::external_agents::session::live::{SessionCommand, CANCELLED_SESSION_LOST};
+use crate::external_agents::spawn::{cli_command, fold_stderr, kill_agent_process_tree};
+use crate::external_agents::types::UnifiedAgentEvent;
+use crate::proc::NoConsoleWindow;
+
+const INIT_TIMEOUT: Duration = Duration::from_secs(45);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const STDERR_CHARS: usize = 8192;
+
+#[derive(Default, Clone, Debug)]
+struct Usage {
+    input: u64,
+    output: u64,
+    thinking: u64,
+    cache: u64,
+    total: u64,
+}
+
+impl Usage {
+    fn parse(v: &Value) -> Self {
+        let n = |k| v.get(k).and_then(Value::as_u64).unwrap_or(0);
+        Self {
+            input: n("input_tokens"),
+            output: n("output_tokens"),
+            thinking: n("thinking_tokens"),
+            cache: n("cache_read_tokens"),
+            total: n("total_tokens"),
+        }
+    }
+
+    fn add(&mut self, other: &Self) {
+        self.input = self.input.saturating_add(other.input);
+        self.output = self.output.saturating_add(other.output);
+        self.thinking = self.thinking.saturating_add(other.thinking);
+        self.cache = self.cache.saturating_add(other.cache);
+        self.total = self.total.saturating_add(other.total);
+    }
+
+    fn since(&self, previous: &Self) -> Self {
+        Self {
+            input: self.input.saturating_sub(previous.input),
+            output: self.output.saturating_sub(previous.output),
+            thinking: self.thinking.saturating_sub(previous.thinking),
+            cache: self.cache.saturating_sub(previous.cache),
+            total: self.total.saturating_sub(previous.total),
+        }
+    }
+
+    fn model_usage(&self) -> ModelUsage {
+        // agy 1.1.26: input=5969, output=554, cache=8132, total=6523.
+        // Cache is disjoint from input (and excluded from native total), while thinking
+        // is already inside output. Kivio total measures context including cached input.
+        ModelUsage {
+            input_tokens: Some(self.input),
+            output_tokens: Some(self.output),
+            total_tokens: Some(
+                self.input
+                    .saturating_add(self.output)
+                    .saturating_add(self.cache),
+            ),
+            reasoning_tokens: Some(self.thinking),
+            cached_input_tokens: Some(self.cache),
+            cache_creation_input_tokens: None,
+            context_window_tokens: None,
+        }
+    }
+}
+
+#[derive(Default)]
+struct TurnStream {
+    text: String,
+    tools: HashSet<String>,
+    finished_tools: HashSet<String>,
+    step_usage: HashMap<u64, Usage>,
+}
+
+impl TurnStream {
+    fn handle(&mut self, value: &Value, sink: &mut dyn FnMut(UnifiedAgentEvent)) {
+        if value["event"] != "step_update" {
+            return;
+        }
+        let step = &value["step_update"];
+        let Some(index) = step["step_index"].as_u64() else {
+            return;
+        };
+        if step["usage"].is_object() {
+            self.step_usage.insert(index, Usage::parse(&step["usage"]));
+        }
+        match step["step_type"].as_str() {
+            Some("agent_response") => {
+                if let Some(delta) = step["text_delta"].as_str().filter(|s| !s.is_empty()) {
+                    self.text.push_str(delta);
+                    sink(UnifiedAgentEvent::TextDelta {
+                        delta: delta.into(),
+                    });
+                }
+            }
+            Some("tool") => {
+                let id = format!(
+                    "agy-{}-{index}",
+                    step["conversation_id"].as_str().unwrap_or("step")
+                );
+                let info = &step["tool_info"];
+                let terminal = matches!(
+                    step["state"].as_str(),
+                    Some("DONE" | "ERROR" | "CANCELED" | "INTERRUPTED")
+                );
+                let name = info["name"]
+                    .as_str()
+                    .or_else(|| step["tool_name"].as_str())
+                    .unwrap_or("tool");
+                // Some ACTIVE transitions have only a name. Wait for parameters (or DONE)
+                // rather than creating a permanently empty tool card.
+                if (info.get("parameters").is_some() || terminal) && self.tools.insert(id.clone()) {
+                    sink(UnifiedAgentEvent::ToolUse {
+                        id: id.clone(),
+                        name: name.into(),
+                        input: info.get("parameters").cloned().unwrap_or_else(|| json!({})),
+                    });
+                }
+                if terminal && self.finished_tools.insert(id.clone()) {
+                    let error = info.get("error").filter(|v| !v.is_null());
+                    let output = error.or_else(|| info.get("output"));
+                    let content = output
+                        .map(|v| {
+                            v.as_str()
+                                .map(str::to_string)
+                                .unwrap_or_else(|| v.to_string())
+                        })
+                        .unwrap_or_else(|| {
+                            if step["state"] == "DONE" {
+                                String::new()
+                            } else {
+                                format!(
+                                    "Tool ended with {}",
+                                    step["state"].as_str().unwrap_or("ERROR")
+                                )
+                            }
+                        });
+                    sink(UnifiedAgentEvent::ToolResult {
+                        tool_use_id: id,
+                        content,
+                        is_error: error.is_some() || step["state"] != "DONE",
+                    });
+                }
+            }
+            _ => {} // Unknown future steps must not break the conversation.
+        }
+    }
+
+    fn finish(
+        &self,
+        result: &Value,
+        previous: &mut Option<Usage>,
+        sink: &mut dyn FnMut(UnifiedAgentEvent),
+    ) -> Result<(), String> {
+        // result.response repeats the streamed text. Only use it when no text was streamed.
+        if self.text.is_empty() {
+            if let Some(text) = result["response"].as_str().filter(|s| !s.is_empty()) {
+                sink(UnifiedAgentEvent::TextDelta { delta: text.into() });
+            }
+        }
+        let cumulative = result
+            .get("usage")
+            .filter(|v| v.is_object())
+            .map(Usage::parse);
+        let usage = if !self.step_usage.is_empty() {
+            // Step counters are per-step, including the FIRST turn after --conversation.
+            // Subtracting zero from that first cumulative result would bill the old history again.
+            let mut sum = Usage::default();
+            for item in self.step_usage.values() {
+                sum.add(item);
+            }
+            Some(sum)
+        } else {
+            cumulative
+                .as_ref()
+                .zip(previous.as_ref())
+                .map(|(current, old)| current.since(old))
+        };
+        if let Some(usage) = usage {
+            sink(UnifiedAgentEvent::Usage {
+                usage: usage.model_usage(),
+            });
+        }
+        if cumulative.is_some() {
+            *previous = cumulative;
+        }
+        if let Some(denied) = result["denied_actions"]
+            .as_array()
+            .filter(|v| !v.is_empty())
+        {
+            let names: Vec<_> = denied
+                .iter()
+                .filter_map(|v| v["display_name"].as_str().or_else(|| v["action"].as_str()))
+                .collect();
+            let message = format!("Antigravity CLI 权限配置拒绝了操作：{}。请调整 CLI 的 permissions.allow 或聊天底栏权限模式。", names.join(", "));
+            if self.text.trim().is_empty()
+                && result["response"].as_str().unwrap_or("").trim().is_empty()
+            {
+                return Err(message);
+            }
+            sink(UnifiedAgentEvent::StatusNote { text: message });
+        }
+        match result["status"].as_str() {
+            Some("SUCCESS") => Ok(()),
+            Some("CANCELED" | "INTERRUPTED") => Err("cancelled".into()),
+            status => Err(result["error"]
+                .as_str()
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    format!(
+                        "Antigravity turn ended with {}",
+                        status.unwrap_or("missing status")
+                    )
+                })),
+        }
+    }
+}
+
+pub struct AntigravitySession {
+    child: Child,
+    stdin: ChildStdin,
+    reader: Lines<BufReader<ChildStdout>>,
+    stderr_task: tokio::task::JoinHandle<()>,
+    stderr_rx: mpsc::Receiver<String>,
+    stderr_tail: Arc<Mutex<String>>,
+    native_id: String,
+    previous_usage: Option<Usage>,
+}
+
+impl AntigravitySession {
+    pub async fn connect(
+        bin: &Path,
+        args: &[String],
+        cwd: &Path,
+        resume: Option<&str>,
+    ) -> Result<Self, String> {
+        let mut command = cli_command(bin);
+        command
+            .args(args)
+            .current_dir(cwd)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .no_console_window()
+            .kill_on_drop(true);
+        if let Some(id) = resume {
+            command.args(["--conversation", id]);
+        }
+        #[cfg(unix)]
+        command.process_group(0);
+        let mut child = command
+            .spawn()
+            .map_err(|e| format!("Start Antigravity CLI: {e}"))?;
+        let stdin = child.stdin.take().ok_or("Antigravity stdin unavailable")?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or("Antigravity stdout unavailable")?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or("Antigravity stderr unavailable")?;
+        let tail = Arc::new(Mutex::new(String::new()));
+        let stderr_tail = tail.clone();
+        let (stderr_tx, stderr_rx) = mpsc::channel(32);
+        let stderr_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                {
+                    let mut tail = tail.lock().unwrap_or_else(|e| e.into_inner());
+                    tail.push_str(&line);
+                    tail.push('\n');
+                    if tail.chars().count() > STDERR_CHARS {
+                        *tail = tail
+                            .chars()
+                            .rev()
+                            .take(STDERR_CHARS)
+                            .collect::<String>()
+                            .chars()
+                            .rev()
+                            .collect();
+                    }
+                }
+                // Never let a full diagnostics channel block the child's stderr pipe.
+                let _ = stderr_tx.try_send(line);
+            }
+        });
+        let mut session = Self {
+            child,
+            stdin,
+            reader: BufReader::new(stdout).lines(),
+            stderr_task,
+            stderr_rx,
+            stderr_tail,
+            native_id: String::new(),
+            previous_usage: resume.is_none().then(Usage::default),
+        };
+        let init = timeout(INIT_TIMEOUT, async {
+            loop {
+                let line = session.reader.next_line().await.map_err(|e| e.to_string())?.ok_or("Antigravity exited before init")?;
+                if line.trim().is_empty() { continue; }
+                let value: Value = serde_json::from_str(&line).map_err(|e| format!("Invalid Antigravity init: {e}"))?;
+                if value["event"] == "init" {
+                    let id = value["conversation_id"].as_str().filter(|id| !id.is_empty()).ok_or("Antigravity init missing conversation_id")?;
+                    if resume.is_some_and(|expected| expected != id) { return Err("Antigravity resumed a different conversation; refusing to replace the binding".into()); }
+                    return Ok::<String, String>(id.into());
+                }
+                if value["event"] == "result" { return Err(value["result"]["error"].as_str().unwrap_or("Antigravity failed before init").into()); }
+            }
+        }).await.unwrap_or_else(|_| Err("Antigravity init timed out; check agy version and sign-in".into()));
+        match init {
+            Ok(id) => {
+                session.native_id = id;
+                Ok(session)
+            }
+            Err(error) => {
+                session.shutdown().await;
+                Err(fold_stderr(
+                    error,
+                    &session
+                        .stderr_tail
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner()),
+                ))
+            }
+        }
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.native_id
+    }
+    pub fn child_pid(&self) -> Option<u32> {
+        self.child.id()
+    }
+
+    async fn shutdown(&mut self) {
+        kill_agent_process_tree(&mut self.child);
+        let _ = timeout(SHUTDOWN_TIMEOUT, self.child.wait()).await;
+        if timeout(SHUTDOWN_TIMEOUT, &mut self.stderr_task)
+            .await
+            .is_err()
+        {
+            self.stderr_task.abort();
+        }
+    }
+
+    async fn run_turn(
+        &mut self,
+        prompt: &str,
+        events: &mpsc::Sender<UnifiedAgentEvent>,
+        commands: &mut mpsc::Receiver<SessionCommand>,
+    ) -> Result<(), String> {
+        // Built-in slash commands emit non-protocol reports and can terminate this session.
+        if prompt.trim_start().starts_with('/') {
+            return Err(
+                "Antigravity 流式会话暂不支持斜杠命令，请使用模型/权限设置或原生终端。".into(),
+            );
+        }
+        let line = format!("{}\n", json!({"event":"user","message":{"content":prompt}}));
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|e| e.to_string())?;
+        self.stdin.flush().await.map_err(|e| e.to_string())?;
+        let mut stream = TurnStream::default();
+        let mut stderr_open = true;
+        loop {
+            tokio::select! {
+                command = commands.recv() => match command {
+                    Some(SessionCommand::Cancel | SessionCommand::Close) | None => return Err(CANCELLED_SESSION_LOST.into()),
+                    Some(SessionCommand::Steer { accepted, .. }) => { let _ = accepted.send(false); }
+                    Some(SessionCommand::RunTurn { done, .. }) => { let _ = done.send(Err("Antigravity session already busy".into())); }
+                    Some(SessionCommand::StopTask { .. }) => {}
+                },
+                note = self.stderr_rx.recv(), if stderr_open => match note {
+                    Some(text) if !text.trim().is_empty() => { let _ = events.send(UnifiedAgentEvent::StatusNote { text }).await; }
+                    None => stderr_open = false,
+                    _ => {}
+                },
+                line = self.reader.next_line() => {
+                    let line = line.map_err(|e| e.to_string())?.ok_or("Antigravity exited before result")?;
+                    if line.trim().is_empty() { continue; }
+                    let value: Value = serde_json::from_str(&line).map_err(|e| format!("Invalid Antigravity stream: {e}"))?;
+                    let payload = match value["event"].as_str() {
+                        Some("result") => &value["result"],
+                        Some("step_update") => &value["step_update"],
+                        _ => &value,
+                    };
+                    if payload["conversation_id"].as_str().is_some_and(|id| !id.is_empty() && id != self.native_id) {
+                        return Err("Antigravity event belongs to a different conversation".into());
+                    }
+                    let mut emitted = Vec::new();
+                    stream.handle(&value, &mut |event| emitted.push(event));
+                    let result = (value["event"] == "result").then(|| stream.finish(&value["result"], &mut self.previous_usage, &mut |event| emitted.push(event)));
+                    for event in emitted { events.send(event).await.map_err(|_| "closed".to_string())?; }
+                    if let Some(result) = result { return result; }
+                }
+            }
+        }
+    }
+}
+
+impl Drop for AntigravitySession {
+    fn drop(&mut self) {
+        kill_agent_process_tree(&mut self.child);
+        self.stderr_task.abort();
+    }
+}
+
+pub fn spawn_antigravity_session_actor(
+    mut session: AntigravitySession,
+) -> mpsc::Sender<SessionCommand> {
+    let (tx, mut rx) = mpsc::channel(8);
+    tokio::spawn(async move {
+        loop {
+            let command = tokio::select! {
+                command = rx.recv() => match command { Some(command) => command, None => break },
+                _ = session.child.wait() => break,
+            };
+            match command {
+                SessionCommand::RunTurn {
+                    prompt,
+                    images,
+                    events,
+                    done,
+                    ..
+                } => {
+                    let result = if images.is_empty() {
+                        session.run_turn(&prompt, &events, &mut rx).await
+                    } else {
+                        Err("Antigravity stream accepts text only; images must be supplied as file paths".into())
+                    };
+                    if let Err(error) = result {
+                        session.shutdown().await;
+                        let error = if error == CANCELLED_SESSION_LOST
+                            || error == "cancelled"
+                            || error == "closed"
+                        {
+                            error
+                        } else {
+                            fold_stderr(
+                                error,
+                                &session
+                                    .stderr_tail
+                                    .lock()
+                                    .unwrap_or_else(|e| e.into_inner()),
+                            )
+                        };
+                        let _ = done.send(Err(error));
+                        return;
+                    }
+                    let _ = done.send(Ok(()));
+                }
+                SessionCommand::Close | SessionCommand::Cancel => break,
+                SessionCommand::Steer { accepted, .. } => {
+                    let _ = accepted.send(false);
+                }
+                SessionCommand::StopTask { .. } => {}
+            }
+        }
+        session.shutdown().await;
+    });
+    tx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn ask(control: &mpsc::Sender<SessionCommand>, prompt: &str) -> Vec<UnifiedAgentEvent> {
+        let (events, mut rx) = mpsc::channel(256);
+        let (done, completion) = tokio::sync::oneshot::channel();
+        control
+            .send(SessionCommand::RunTurn {
+                prompt: prompt.into(),
+                model: None,
+                reasoning: None,
+                images: vec![],
+                extra_writable_roots: vec![],
+                events,
+                done,
+                approvals: None,
+            })
+            .await
+            .unwrap();
+        timeout(Duration::from_secs(90), completion)
+            .await
+            .expect("turn timeout")
+            .unwrap()
+            .unwrap();
+        let mut events = vec![];
+        while let Some(event) = rx.recv().await {
+            events.push(event);
+        }
+        events
+    }
+
+    fn text(events: &[UnifiedAgentEvent]) -> String {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                UnifiedAgentEvent::TextDelta { delta } => Some(delta.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    #[ignore = "requires signed-in agy; runs model requests in an isolated temp workspace"]
+    async fn live_antigravity_multiturn_tools_cancel_and_resume() {
+        use crate::external_agents::defs::antigravity::ANTIGRAVITY_AGENT_DEF;
+        use crate::external_agents::types::{RuntimeBuildOptions, RuntimeContext};
+        let bin = crate::external_agents::spawn::resolve_binary(&ANTIGRAVITY_AGENT_DEF)
+            .await
+            .expect("agy binary");
+        let cwd = std::env::temp_dir().join(format!("kivio-agy-probe-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&cwd).unwrap();
+        let fixture = cwd.join("probe.txt");
+        std::fs::write(&fixture, "AGY_TOOL_PROBE_72941").unwrap();
+        let args = (ANTIGRAVITY_AGENT_DEF.build_args)(
+            &RuntimeContext {
+                extra_allowed_dirs: vec![],
+                resume_session_id: None,
+                new_session_id: None,
+                include_partial_messages: true,
+            },
+            &RuntimeBuildOptions {
+                model: None,
+                reasoning: None,
+                sandbox: Some("plan".into()),
+            },
+            None,
+        );
+        let session = AntigravitySession::connect(&bin, &args, &cwd, None)
+            .await
+            .unwrap();
+        let id = session.session_id().to_string();
+        let pid = session.child_pid();
+        let control = spawn_antigravity_session_actor(session);
+        assert!(text(
+            &ask(
+                &control,
+                "Do not use tools. Remember the word kumquat. Reply only OK."
+            )
+            .await
+        )
+        .contains("OK"));
+        assert!(text(
+            &ask(
+                &control,
+                "Do not use tools. What word did I ask you to remember? Reply only that word."
+            )
+            .await
+        )
+        .to_lowercase()
+        .contains("kumquat"));
+        let events = ask(&control, &format!("For this turn use view_file to read exactly this absolute file path: {}. Return its contents. Do not search other directories, edit files or execute shell commands.", fixture.display())).await;
+        assert!(
+            text(&events).contains("AGY_TOOL_PROBE_72941"),
+            "file response: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, UnifiedAgentEvent::ToolUse { .. })),
+            "tool start missing: {events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, UnifiedAgentEvent::ToolResult { .. })),
+            "tool end missing: {events:?}"
+        );
+        // Cancel an active turn. Closing stdin alone would let it keep running.
+        let (events, _rx) = mpsc::channel(256);
+        let (done, completion) = tokio::sync::oneshot::channel();
+        control
+            .send(SessionCommand::RunTurn {
+                prompt: "Do not use tools. Explain the first 100 prime numbers in detail.".into(),
+                model: None,
+                reasoning: None,
+                images: vec![],
+                extra_writable_roots: vec![],
+                events,
+                done,
+                approvals: None,
+            })
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        control.send(SessionCommand::Cancel).await.unwrap();
+        assert_eq!(
+            timeout(Duration::from_secs(20), completion)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap_err(),
+            CANCELLED_SESSION_LOST
+        );
+        timeout(Duration::from_secs(5), control.closed())
+            .await
+            .unwrap();
+        let session = AntigravitySession::connect(&bin, &args, &cwd, Some(&id))
+            .await
+            .unwrap();
+        assert_eq!(session.session_id(), id);
+        assert_ne!(session.child_pid(), pid);
+        let control = spawn_antigravity_session_actor(session);
+        let events = ask(
+            &control,
+            "Do not use tools. What word did I ask you to remember earlier? Reply only that word.",
+        )
+        .await;
+        assert!(text(&events).to_lowercase().contains("kumquat"));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, UnifiedAgentEvent::Usage { .. })));
+        control.send(SessionCommand::Close).await.unwrap();
+        timeout(Duration::from_secs(20), control.closed())
+            .await
+            .unwrap();
+        // Only the exact fixture created above is removed; never recursively delete the workspace.
+        std::fs::remove_file(fixture).unwrap();
+        let _ = std::fs::remove_dir(cwd);
+    }
+
+    #[test]
+    fn streams_deltas_once_and_uses_per_step_usage_after_resume() {
+        let mut stream = TurnStream::default();
+        let mut events = vec![];
+        for (state, delta) in [("ACTIVE", "kumquat"), ("DONE", "\n")] {
+            stream.handle(&json!({"event":"step_update","step_update":{"step_index":3,"step_type":"agent_response","state":state,"text_delta":delta,"usage":{"input_tokens":100,"output_tokens":7,"thinking_tokens":5,"cache_read_tokens":80,"total_tokens":107}}}), &mut |e| events.push(e));
+        }
+        stream.finish(&json!({"status":"SUCCESS","response":"kumquat\n","usage":{"input_tokens":900,"output_tokens":80,"total_tokens":980}}), &mut None, &mut |e| events.push(e)).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, UnifiedAgentEvent::TextDelta { .. }))
+                .count(),
+            2
+        );
+        let UnifiedAgentEvent::Usage { usage } = events.last().unwrap() else {
+            panic!("usage missing")
+        };
+        assert_eq!(usage.total_tokens, Some(187));
+        assert_eq!(usage.reasoning_tokens, Some(5));
+        assert_eq!(usage.cached_input_tokens, Some(80));
+    }
+
+    #[test]
+    fn tools_pair_active_and_done_and_preserve_errors() {
+        let mut stream = TurnStream::default();
+        let mut events = vec![];
+        for state in ["ACTIVE", "ERROR", "ERROR"] {
+            stream.handle(&json!({"event":"step_update","step_update":{"conversation_id":"native","step_index":4,"step_type":"tool","state":state,"tool_name":"run_command","tool_info":{"parameters":{"CommandLine":"echo hi"},"error":{"type":"denied","message":"permission denied"}}}}), &mut |e| events.push(e));
+        }
+        assert_eq!(events.len(), 2);
+        assert!(
+            matches!(&events[0], UnifiedAgentEvent::ToolUse { id, input, .. } if id == "agy-native-4" && input["CommandLine"] == "echo hi")
+        );
+        assert!(
+            matches!(&events[1], UnifiedAgentEvent::ToolResult { is_error: true, content, .. } if content.contains("permission denied"))
+        );
+    }
+
+    #[test]
+    fn cumulative_fallback_is_differenced_and_failed_status_is_not_success() {
+        let stream = TurnStream::default();
+        let mut previous = Some(Usage {
+            input: 100,
+            output: 10,
+            total: 110,
+            ..Default::default()
+        });
+        let mut events = vec![];
+        assert!(stream.finish(&json!({"status":"ERROR","error":"invalid model","usage":{"input_tokens":120,"output_tokens":13,"total_tokens":133}}), &mut previous, &mut |e| events.push(e)).unwrap_err().contains("invalid model"));
+        assert!(
+            matches!(&events[0], UnifiedAgentEvent::Usage { usage } if usage.total_tokens == Some(23))
+        );
+        assert_eq!(
+            stream
+                .finish(&json!({"status":"INTERRUPTED"}), &mut previous, &mut |_| {})
+                .unwrap_err(),
+            "cancelled"
+        );
+        assert!(stream
+            .finish(&json!({"status":"WAITING"}), &mut previous, &mut |_| {})
+            .is_err());
+    }
+
+    #[test]
+    fn soft_denial_with_success_status_never_becomes_an_empty_success() {
+        let stream = TurnStream::default();
+        let result = json!({"status":"SUCCESS","response":"","denied_actions":[{"action":"read_file","display_name":"ListDir"}]});
+        assert!(stream
+            .finish(&result, &mut None, &mut |_| {})
+            .unwrap_err()
+            .contains("ListDir"));
+    }
+
+    #[test]
+    fn final_only_response_is_preserved_and_unknown_steps_are_ignored() {
+        let mut stream = TurnStream::default();
+        let mut events = vec![];
+        stream.handle(&json!({"event":"step_update","step_update":{"step_index":5,"step_type":"future_step"}}), &mut |e| events.push(e));
+        stream
+            .finish(
+                &json!({"status":"SUCCESS","response":"answer"}),
+                &mut None,
+                &mut |e| events.push(e),
+            )
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(text(&events), "answer");
+    }
+}

--- a/src-tauri/src/external_agents/session/antigravity.rs
+++ b/src-tauri/src/external_agents/session/antigravity.rs
@@ -393,7 +393,10 @@ impl AntigravitySession {
                 if name == "help" {
                     let _ = events
                         .send(UnifiedAgentEvent::TextDelta {
-                            delta: crate::external_agents::antigravity_slash::help_text(),
+                            delta: crate::external_agents::antigravity_slash::render_report(
+                                name,
+                                &crate::external_agents::antigravity_slash::help_text(),
+                            ),
                         })
                         .await;
                     return Ok(());
@@ -413,7 +416,9 @@ impl AntigravitySession {
                     }
                 };
                 let text = match result {
-                    Ok(text) if !text.is_empty() => text,
+                    Ok(text) if !text.is_empty() => {
+                        crate::external_agents::antigravity_slash::render_report(name, &text)
+                    }
                     Ok(_) => "命令已完成，没有返回内容。".into(),
                     Err(error) => format!("命令执行失败：{error}"),
                 };
@@ -565,13 +570,22 @@ mod tests {
     }
 
     fn text(events: &[UnifiedAgentEvent]) -> String {
-        events
+        let text: String = events
             .iter()
             .filter_map(|event| match event {
                 UnifiedAgentEvent::TextDelta { delta } => Some(delta.as_str()),
                 _ => None,
             })
-            .collect()
+            .collect();
+        if let Some(body) = text
+            .strip_prefix("```kivio-cli-report\n")
+            .and_then(|v| v.strip_suffix("\n```"))
+        {
+            if let Ok(value) = serde_json::from_str::<Value>(body) {
+                return value["output"].as_str().unwrap_or_default().to_string();
+            }
+        }
+        text
     }
 
     #[tokio::test]

--- a/src-tauri/src/external_agents/session/antigravity.rs
+++ b/src-tauri/src/external_agents/session/antigravity.rs
@@ -2,7 +2,7 @@
 //! https://antigravity.google/docs/cli/headless/
 //! One init per process, one result per turn. No control RPCs or native image blocks.
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -234,6 +234,9 @@ impl TurnStream {
 }
 
 pub struct AntigravitySession {
+    bin: PathBuf,
+    cwd: PathBuf,
+    args: Vec<String>,
     child: Child,
     stdin: ChildStdin,
     reader: Lines<BufReader<ChildStdout>>,
@@ -303,6 +306,9 @@ impl AntigravitySession {
             }
         });
         let mut session = Self {
+            bin: bin.to_path_buf(),
+            cwd: cwd.to_path_buf(),
+            args: args.to_vec(),
             child,
             stdin,
             reader: BufReader::new(stdout).lines(),
@@ -367,11 +373,57 @@ impl AntigravitySession {
         events: &mpsc::Sender<UnifiedAgentEvent>,
         commands: &mut mpsc::Receiver<SessionCommand>,
     ) -> Result<(), String> {
-        // Built-in slash commands emit non-protocol reports and can terminate this session.
-        if prompt.trim_start().starts_with('/') {
-            return Err(
-                "Antigravity 流式会话暂不支持斜杠命令，请使用模型/权限设置或原生终端。".into(),
-            );
+        use crate::external_agents::antigravity_slash::{
+            command_name, is_report, is_terminal_only, report,
+        };
+        if let Some(name) = command_name(prompt) {
+            let has_args = prompt.trim().split_whitespace().count() > 1;
+            if is_terminal_only(name) || (is_report(name) && has_args) {
+                let message = if is_report(name) {
+                    format!("/{name} 当前适配为只读查询，请不带参数执行。模型、推理强度和权限可在会话菜单中修改；其他配置请在 agy 原生终端中修改。")
+                } else {
+                    format!("/{name} 需要 Antigravity 交互式终端，当前流式协议没有对应接口。输入 /help 可查看已适配命令。")
+                };
+                let _ = events
+                    .send(UnifiedAgentEvent::TextDelta { delta: message })
+                    .await;
+                return Ok(());
+            }
+            if is_report(name) {
+                if name == "help" {
+                    let _ = events
+                        .send(UnifiedAgentEvent::TextDelta {
+                            delta: crate::external_agents::antigravity_slash::help_text(),
+                        })
+                        .await;
+                    return Ok(());
+                }
+                // A failed report must not close the native conversation. Cancel/Close
+                // still cancels the subprocess future (kill_on_drop) and the session.
+                let pending = report(&self.bin, &self.cwd, &self.args, prompt);
+                tokio::pin!(pending);
+                let result = loop {
+                    tokio::select! {
+                        result = &mut pending => break result,
+                        command = commands.recv() => match command {
+                            Some(SessionCommand::Steer { accepted, .. }) => { let _ = accepted.send(false); }
+                            Some(SessionCommand::StopTask { .. }) => {}
+                            _ => return Err(CANCELLED_SESSION_LOST.into()),
+                        }
+                    }
+                };
+                let text = match result {
+                    Ok(text) if !text.is_empty() => text,
+                    Ok(_) => "命令已完成，没有返回内容。".into(),
+                    Err(error) => format!("命令执行失败：{error}"),
+                };
+                let _ = events
+                    .send(UnifiedAgentEvent::TextDelta { delta: text })
+                    .await;
+                return Ok(());
+            }
+            // Skill slash commands are expanded by agy, preserving native arguments
+            // and the existing conversation. Do not prepend Kivio instructions.
         }
         let line = format!("{}\n", json!({"event":"user","message":{"content":prompt}}));
         self.stdin
@@ -562,6 +614,29 @@ mod tests {
             .await
         )
         .contains("OK"));
+        let catalog = crate::external_agents::antigravity_slash::builtin_commands();
+        assert!(catalog.iter().any(|command| command.name == "usage"));
+        let report = ask(&control, "/help").await;
+        assert!(text(&report).contains("/usage"));
+        assert!(!report
+            .iter()
+            .any(|event| matches!(event, UnifiedAgentEvent::Usage { .. })));
+        assert!(text(&ask(&control, "/model low").await).contains("只读"));
+        assert!(text(&ask(&control, "/clear").await).contains("交互式终端"));
+        let skills = text(&ask(&control, "/skills").await);
+        if skills
+            .lines()
+            .any(|line| line.starts_with("antigravity-guide\t"))
+        {
+            assert!(text(
+                &ask(
+                    &control,
+                    "/antigravity-guide Reply with exactly AGY_SLASH_OK. Do not use tools."
+                )
+                .await
+            )
+            .contains("AGY_SLASH_OK"));
+        }
         assert!(text(
             &ask(
                 &control,

--- a/src-tauri/src/external_agents/session/mod.rs
+++ b/src-tauri/src/external_agents/session/mod.rs
@@ -12,6 +12,7 @@ use crate::external_agents::types::ExternalAgentSession;
 
 pub mod acp;
 mod acp_terminal;
+pub mod antigravity;
 pub mod claude_init;
 /// 常驻 `claude` 会话（B1）：一个会话一个进程。
 pub mod claude_stream;

--- a/src-tauri/src/external_agents/slash.rs
+++ b/src-tauri/src/external_agents/slash.rs
@@ -132,6 +132,13 @@ pub async fn list_external_cli_slash_commands(
     let def = get_agent_def(agent_id).ok_or_else(|| format!("未知外部 Agent: {agent_id}"))?;
 
     // Cheap, dependency-free strategies first — no CLI availability check needed.
+    if def.slash_strategy == SlashStrategy::Antigravity {
+        return Ok((
+            true,
+            crate::external_agents::antigravity_slash::builtin_commands(),
+            None,
+        ));
+    }
     if def.slash_strategy == SlashStrategy::None {
         return Ok((
             false,
@@ -248,7 +255,9 @@ pub async fn list_external_cli_slash_commands(
             .await
             .unwrap_or_default()
         }
-        SlashStrategy::Dsh | SlashStrategy::None => unreachable!("cheap strategies handled above"),
+        SlashStrategy::Dsh | SlashStrategy::Antigravity | SlashStrategy::None => {
+            unreachable!("cheap strategies handled above")
+        }
     };
 
     // R1: cache the result even when empty (negative cache) so切会话/切 agent 不再每次重探。

--- a/src-tauri/src/external_agents/spawn.rs
+++ b/src-tauri/src/external_agents/spawn.rs
@@ -354,6 +354,21 @@ pub async fn resolve_binary(def: &RuntimeAgentDef) -> Option<PathBuf> {
             }
         }
     }
+    // The desktop process may still have the PATH from before the official agy install.
+    if def.id == "antigravity" {
+        let path = if cfg!(windows) {
+            std::env::var_os("LOCALAPPDATA")
+                .map(PathBuf::from)
+                .map(|p| p.join("agy/bin/agy.exe"))
+        } else {
+            directories::UserDirs::new().map(|d| d.home_dir().join(".local/bin/agy"))
+        };
+        if let Some(path) = path.filter(|p| p.is_file()) {
+            if probe_executable_cached(&path, def.version_args).await {
+                return Some(path);
+            }
+        }
+    }
     // Windows PATH 上没有能拉起来的 Win32 候选时，再看 WSL 里的 Linux 安装。
     // 不插到 PATH 候选前面：本机已经装了 Windows 版 CLI 的人不能被 WSL 里同名二进制抢走。
     for candidate in std::iter::once(def.bin).chain(def.fallback_bins.iter().copied()) {

--- a/src-tauri/src/external_agents/stream/mod.rs
+++ b/src-tauri/src/external_agents/stream/mod.rs
@@ -10,7 +10,8 @@ pub fn create_stream_handler(format: StreamFormat) -> StreamHandler {
         StreamFormat::ClaudeStreamJson => StreamHandler(claude::ClaudeStreamState::default()),
         // PiRpc / AcpJsonRpc / CodexAppServer / DshJsonRpc are driven by dedicated session
         // runners in run.rs and never reach this factory.
-        StreamFormat::PiRpc
+        StreamFormat::AntigravityStreamJson
+        | StreamFormat::PiRpc
         | StreamFormat::AcpJsonRpc
         | StreamFormat::CodexAppServer
         | StreamFormat::DshJsonRpc => {

--- a/src-tauri/src/external_agents/types.rs
+++ b/src-tauri/src/external_agents/types.rs
@@ -7,6 +7,7 @@ use crate::chat::model::ModelUsage;
 #[serde(rename_all = "snake_case")]
 pub enum StreamFormat {
     ClaudeStreamJson,
+    AntigravityStreamJson,
     PiRpc,
     AcpJsonRpc,
     CodexAppServer,

--- a/src-tauri/src/external_agents/types.rs
+++ b/src-tauri/src/external_agents/types.rs
@@ -53,6 +53,8 @@ pub enum SlashStrategy {
     /// Discover via `session/commands` (`ctx.commands.list`) after the kivio
     /// profile mounts. Builtins are only the pre-connect fallback.
     Dsh,
+    /// Kivio-maintained builtins, with standalone reports and native skill passthrough.
+    Antigravity,
     /// No discoverable slash commands for this CLI in headless mode.
     None,
 }

--- a/src/chat/AgentIcon.tsx
+++ b/src/chat/AgentIcon.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from 'react'
+import Antigravity from '@lobehub/icons/es/Antigravity/components/Color'
 
 const ICON_EXT: Record<string, 'svg'> = {
   claude: 'svg',
@@ -22,6 +23,9 @@ interface AgentIconProps {
 }
 
 export function AgentIcon({ id, size = 20, className }: AgentIconProps) {
+  if (id === 'antigravity') {
+    return <Antigravity size={size} className={className} aria-hidden="true" />
+  }
   const cls = ['agent-icon', className].filter(Boolean).join(' ')
   const ext = ICON_EXT[id]
   if (ext === 'svg' && MONO_ICONS.has(id)) {

--- a/src/chat/ChatMarkdown.tsx
+++ b/src/chat/ChatMarkdown.tsx
@@ -25,6 +25,7 @@ import { useConversationTransition } from './conversationTransitionStore'
 import { api } from '../api/tauri'
 import { copyToClipboard } from '../utils/clipboard'
 import { IconButton } from '../components/Button'
+import { CliCommandReport, normalizeLegacyCliReport, parseCliReport } from './CliCommandReport'
 
 interface ChatMarkdownProps {
   content: string
@@ -757,6 +758,10 @@ function MarkdownPre({ children }: { children?: ReactNode }) {
     const languageMatch = /language-([\w-]+)/.exec(child.props.className ?? '')
     const language = normalizeCodeLanguage(languageMatch?.[1])
     const code = codeChildrenToString(child.props.children)
+    if (language === 'kivio-cli-report') {
+      const report = parseCliReport(code)
+      if (report) return <CliCommandReport report={report} />
+    }
     if (language === 'html') {
       return <HtmlCodePreview html={code} />
     }
@@ -1119,7 +1124,7 @@ const FullSettledMarkdown = memo(function FullSettledMarkdown({
   const normalized = useMemo(() => {
     const build = () => {
       const normalizedContent = preserveLocalMarkdownLinks(
-        normalizeMarkdownForRender(normalizeLegacyErrorDetails(content)),
+        normalizeMarkdownForRender(normalizeLegacyCliReport(normalizeLegacyErrorDetails(content))),
       )
       return { normalized: normalizedContent }
     }

--- a/src/chat/ChatMarkdown.tsx
+++ b/src/chat/ChatMarkdown.tsx
@@ -25,7 +25,8 @@ import { useConversationTransition } from './conversationTransitionStore'
 import { api } from '../api/tauri'
 import { copyToClipboard } from '../utils/clipboard'
 import { IconButton } from '../components/Button'
-import { CliCommandReport, normalizeLegacyCliReport, parseCliReport } from './CliCommandReport'
+import { CliCommandReport } from './CliCommandReport'
+import { normalizeLegacyCliReport, parseCliReport } from './cliCommandReportData'
 
 interface ChatMarkdownProps {
   content: string

--- a/src/chat/CliCommandReport.test.tsx
+++ b/src/chat/CliCommandReport.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import { CliCommandReport, normalizeLegacyCliReport, parseCliReport, parseQuotas } from './CliCommandReport'
+import { CliCommandReport } from './CliCommandReport'
+import { normalizeLegacyCliReport, parseCliReport, parseQuotas } from './cliCommandReportData'
 import { ChatMarkdown } from './ChatMarkdown'
 
 const output = 'Gemini Models\tWeekly Limit Remaining\t89%\t2026-09-11T15:23:59Z\nGemini Models\tFive Hour Limit Remaining\t0%\t2026-09-05T10:39:37Z\nClaude and GPT models\tWeekly Limit Remaining\t100%\t2026-09-12T07:09:02Z'

--- a/src/chat/CliCommandReport.test.tsx
+++ b/src/chat/CliCommandReport.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { CliCommandReport, normalizeLegacyCliReport, parseCliReport, parseQuotas } from './CliCommandReport'
+import { ChatMarkdown } from './ChatMarkdown'
+
+const output = 'Gemini Models\tWeekly Limit Remaining\t89%\t2026-09-11T15:23:59Z\nGemini Models\tFive Hour Limit Remaining\t0%\t2026-09-05T10:39:37Z\nClaude and GPT models\tWeekly Limit Remaining\t100%\t2026-09-12T07:09:02Z'
+
+describe('CLI command panels', () => {
+  it('renders old persisted quota text as remaining bars with reset times', () => {
+    const { container } = render(<ChatMarkdown content={output} />)
+    const bars = screen.getAllByRole('progressbar')
+    expect(bars).toHaveLength(3)
+    expect(bars[0]).toHaveAttribute('aria-valuenow', '89')
+    expect(bars[1]).toHaveAttribute('aria-valuenow', '0')
+    expect(bars[2]).toHaveAttribute('aria-valuenow', '100')
+    expect(container.querySelector('time')).toHaveAttribute('datetime', '2026-09-11T15:23:59Z')
+    expect(container.querySelector('details')).not.toHaveAttribute('open')
+  })
+
+  it('does not discard unrecognized rows or invent quota values', () => {
+    for (const raw of [output + '\nUnexpected new quota type', output.replace('89%', '189%'), output.replace('2026-09-11T15:23:59Z', 'unknown')]) {
+      expect(parseQuotas(raw)).toEqual([])
+      expect(normalizeLegacyCliReport(raw)).toBe(raw)
+    }
+  })
+
+  it('renders versioned reports and filters skills without rendering HTML', () => {
+    const report = { version: 1 as const, agent: 'antigravity' as const, command: 'skills', output: 'review\tInspect changes\ndesign\t<script>alert(1)</script>' }
+    render(<CliCommandReport report={report} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Inspect' } })
+    expect(screen.getByRole('button', { name: '复制 review' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '复制 design' })).toBeNull()
+    expect(document.querySelector('script')).toBeNull()
+    expect(parseCliReport(JSON.stringify(report))).toEqual(report)
+    expect(parseCliReport('{"version":2}')).toBeNull()
+  })
+
+  it('uses the same panel for newly persisted fenced results', () => {
+    render(<ChatMarkdown content={'```kivio-cli-report\n' + JSON.stringify({ version: 1, agent: 'antigravity', command: 'model', output: 'model-id\tModel display name' }) + '\n```'} />)
+    expect(screen.getByRole('region', { name: '当前模型' })).toBeInTheDocument()
+    expect(screen.getByText('Model display name')).toBeInTheDocument()
+  })
+})

--- a/src/chat/CliCommandReport.tsx
+++ b/src/chat/CliCommandReport.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from 'react'
+import { Check, Copy, Search, Terminal } from 'lucide-react'
+import { copyToClipboard } from '../utils/clipboard'
+
+export type CliReport = { version: 1; agent: 'antigravity'; command: string; output: string }
+type Quota = { group: string; window: string; remaining: number; reset: string }
+
+export function parseCliReport(value: string): CliReport | null {
+  try {
+    const v: unknown = JSON.parse(value)
+    if (!v || typeof v !== 'object') return null
+    const r = v as Record<string, unknown>
+    return r.version === 1 && r.agent === 'antigravity' && typeof r.command === 'string'
+      && typeof r.output === 'string' ? r as CliReport : null
+  } catch { return null }
+}
+
+export function parseQuotas(output: string): Quota[] {
+  const lines = output.trim().split(/\r?\n/).filter(Boolean)
+  const rows: Quota[] = []
+  for (const line of lines) {
+    const match = line.match(/^(.+?)\s+(Weekly|Five Hour) Limit Remaining\s+(\d+(?:\.\d+)?)%\s+(\S+)\s*$/)
+    if (!match || Number(match[3]) > 100 || !Number.isFinite(Date.parse(match[4]))) return []
+    rows.push({ group: match[1].trim(), window: match[2] === 'Weekly' ? '每周额度' : '5 小时额度', remaining: Number(match[3]), reset: match[4] })
+  }
+  return rows
+}
+
+// Exact old agy quota reports only; ordinary prose and incomplete streams are unchanged.
+export function normalizeLegacyCliReport(content: string): string {
+  return parseQuotas(content).length ? '```kivio-cli-report\n' + JSON.stringify({
+    version: 1, agent: 'antigravity', command: 'usage', output: content,
+  }) + '\n```' : content
+}
+
+const titles: Record<string, string> = {
+  usage: '模型配额', quota: '模型配额', help: '命令指南', skills: '可用技能',
+  agents: '自定义 Agent', model: '当前模型', effort: '推理强度', config: 'CLI 配置',
+  settings: 'CLI 配置', permissions: '权限配置', hooks: 'Hooks 配置', credits: 'AI Credits', changelog: '更新记录',
+}
+
+function CopyButton({ value, label = '复制原始输出' }: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false)
+  return <button type="button" aria-label={copied ? '已复制' : label} title={label}
+    className="shrink-0 rounded-md p-1.5 text-neutral-400 hover:bg-black/5 hover:text-neutral-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 dark:hover:bg-white/10 dark:hover:text-neutral-100"
+    onClick={async () => { if (await copyToClipboard(value)) setCopied(true) }}>
+    {copied ? <Check size={14} /> : <Copy size={14} />}
+  </button>
+}
+
+function resetLabel(reset: string): string {
+  return new Intl.DateTimeFormat('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false }).format(new Date(reset))
+}
+
+function reportRows(output: string): { name: string; value: string }[] {
+  try {
+    const value: unknown = JSON.parse(output)
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return Object.entries(value).map(([name, v]) => ({ name, value: typeof v === 'string' ? v : JSON.stringify(v, null, 2) }))
+    }
+  } catch { /* native text format */ }
+  return output.split(/\r?\n/).filter(line => line.trim()).map(line => {
+    const match = line.match(/^(.+?)(?:\t+| — |:\s+)(.*)$/)
+    return match ? { name: match[1], value: match[2].replace(/\t/g, ' · ') } : { name: line, value: '' }
+  })
+}
+
+export function CliCommandReport({ report }: { report: CliReport }) {
+  const [query, setQuery] = useState('')
+  const quota = useMemo(() => ['usage', 'quota'].includes(report.command) ? parseQuotas(report.output) : [], [report])
+  const rows = useMemo(() => reportRows(report.output), [report.output])
+  const searchable = ['help', 'skills', 'agents'].includes(report.command)
+  const visible = rows.filter(row => `${row.name} ${row.value}`.toLowerCase().includes(query.toLowerCase()))
+  const groups = [...new Set(quota.map(row => row.group))]
+  return <section aria-label={titles[report.command] ?? `/${report.command}`} className="not-prose my-3 w-full max-w-[600px] overflow-hidden rounded-xl border border-black/[0.07] bg-[var(--bg-primary)] text-sm text-neutral-800 dark:border-white/10 dark:text-neutral-100">
+    <header className="flex items-center gap-2 border-b border-black/5 px-4 py-3 dark:border-white/10">
+      <Terminal size={16} className="text-neutral-400" />
+      <h3 className="m-0 flex-1 text-sm font-semibold">{titles[report.command] ?? '命令结果'}</h3>
+      <span className="font-mono text-[11px] text-neutral-400">/{report.command}</span>
+      <CopyButton value={report.output} />
+    </header>
+    {quota.length > 0 ? <div className="space-y-5 px-4 py-4">
+      {groups.map(group => <div key={group}>
+        <h4 className="mb-3 text-xs font-semibold text-neutral-500 dark:text-neutral-400">{group}</h4>
+        <div className="grid grid-cols-1 gap-4 min-[460px]:grid-cols-2">
+          {quota.filter(row => row.group === group).map(row => <div key={row.window}>
+            <div className="mb-2 flex items-baseline justify-between gap-2">
+              <span className="text-xs">{row.window}</span>
+              <span className="text-xs text-neutral-400">剩余 <strong className="ml-1 text-lg font-semibold tabular-nums text-neutral-800 dark:text-neutral-100">{row.remaining}<span className="text-xs">%</span></strong></span>
+            </div>
+            <div role="progressbar" aria-label={`${group} ${row.window}剩余`} aria-valuenow={row.remaining} aria-valuemin={0} aria-valuemax={100}
+              className="h-1.5 overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+              <div className={`h-full rounded-full ${row.remaining <= 10 ? 'bg-amber-500' : 'bg-emerald-500 dark:bg-emerald-400'}`} style={{ width: `${row.remaining}%` }} />
+            </div>
+            <p className="mb-0 mt-2 text-[11px] text-neutral-400">重置于 <time dateTime={row.reset} title={row.reset}>{resetLabel(row.reset)}</time></p>
+          </div>)}
+        </div>
+      </div>)}
+      <p className="m-0 text-[10px] text-neutral-400">查询时的配额快照 · 重置时间按本地时区显示</p>
+    </div> : <>
+      {searchable && <div className="flex items-center gap-2 border-b border-black/5 px-4 py-2 dark:border-white/10">
+        <Search size={14} className="text-neutral-400" />
+        <input aria-label="筛选命令结果" placeholder="搜索名称或说明…" value={query} onChange={event => setQuery(event.target.value)} className="min-w-0 flex-1 bg-transparent py-1 text-xs outline-none placeholder:text-neutral-400" />
+        <span className="text-[11px] tabular-nums text-neutral-400">{visible.length} 项</span>
+      </div>}
+      <div className="custom-scrollbar max-h-96 overflow-y-auto px-4">
+        {visible.map((row, index) => <div key={`${row.name}:${index}`} className="flex gap-2 border-b border-black/5 py-3 last:border-0 dark:border-white/5">
+          <div className="min-w-0 flex-1">
+            <div className={`break-words ${report.command === 'model' || report.command === 'effort' ? 'text-base font-semibold' : 'text-xs font-medium'}`}>{row.name}</div>
+            {row.value && <div className="mt-1 whitespace-pre-wrap break-words text-xs leading-relaxed text-neutral-500 dark:text-neutral-400">{row.value}</div>}
+          </div>
+          {searchable && (report.command !== 'help' || row.name.startsWith('/')) && <CopyButton value={report.command === 'skills' && !row.name.startsWith('/') ? `/${row.name}` : row.name} label={`复制 ${row.name}`} />}
+        </div>)}
+        {!visible.length && <p className="py-4 text-center text-xs text-neutral-400">没有匹配的结果</p>}
+      </div>
+    </>}
+    <details className="border-t border-black/5 bg-black/[0.015] dark:border-white/10 dark:bg-white/[0.02]">
+      <summary className="cursor-pointer px-4 py-2 text-[11px] text-neutral-400">原始输出</summary>
+      <pre className="custom-scrollbar m-0 max-h-56 overflow-auto whitespace-pre-wrap break-words px-4 pb-3 text-[11px] text-neutral-500">{report.output}</pre>
+    </details>
+  </section>
+}

--- a/src/chat/CliCommandReport.tsx
+++ b/src/chat/CliCommandReport.tsx
@@ -2,36 +2,7 @@ import { useMemo, useState } from 'react'
 import { Check, Copy, Search, Terminal } from 'lucide-react'
 import { copyToClipboard } from '../utils/clipboard'
 
-export type CliReport = { version: 1; agent: 'antigravity'; command: string; output: string }
-type Quota = { group: string; window: string; remaining: number; reset: string }
-
-export function parseCliReport(value: string): CliReport | null {
-  try {
-    const v: unknown = JSON.parse(value)
-    if (!v || typeof v !== 'object') return null
-    const r = v as Record<string, unknown>
-    return r.version === 1 && r.agent === 'antigravity' && typeof r.command === 'string'
-      && typeof r.output === 'string' ? r as CliReport : null
-  } catch { return null }
-}
-
-export function parseQuotas(output: string): Quota[] {
-  const lines = output.trim().split(/\r?\n/).filter(Boolean)
-  const rows: Quota[] = []
-  for (const line of lines) {
-    const match = line.match(/^(.+?)\s+(Weekly|Five Hour) Limit Remaining\s+(\d+(?:\.\d+)?)%\s+(\S+)\s*$/)
-    if (!match || Number(match[3]) > 100 || !Number.isFinite(Date.parse(match[4]))) return []
-    rows.push({ group: match[1].trim(), window: match[2] === 'Weekly' ? '每周额度' : '5 小时额度', remaining: Number(match[3]), reset: match[4] })
-  }
-  return rows
-}
-
-// Exact old agy quota reports only; ordinary prose and incomplete streams are unchanged.
-export function normalizeLegacyCliReport(content: string): string {
-  return parseQuotas(content).length ? '```kivio-cli-report\n' + JSON.stringify({
-    version: 1, agent: 'antigravity', command: 'usage', output: content,
-  }) + '\n```' : content
-}
+import { parseQuotas, type CliReport } from './cliCommandReportData'
 
 const titles: Record<string, string> = {
   usage: '模型配额', quota: '模型配额', help: '命令指南', skills: '可用技能',

--- a/src/chat/RuntimePicker.test.tsx
+++ b/src/chat/RuntimePicker.test.tsx
@@ -57,6 +57,7 @@ describe('ExternalModelSelector', () => {
       fireEvent.click(screen.getByRole('button'))
     })
     expect(screen.getByText('探测失败，显示默认列表')).toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveTextContent('boom')
 
     // 点重试 → 以 force=true 重探。
     act(() => {
@@ -64,6 +65,7 @@ describe('ExternalModelSelector', () => {
     })
     await waitFor(() => expect(detectModels).toHaveBeenCalledTimes(2))
     expect(detectModels.mock.calls[1][2]).toBe(true)
+    await waitFor(() => expect(screen.queryByText('boom')).not.toBeInTheDocument())
   })
 
   it('probed 结果不显示降级提示', async () => {

--- a/src/chat/RuntimePicker.tsx
+++ b/src/chat/RuntimePicker.tsx
@@ -316,6 +316,7 @@ function ExternalModelSelectorBase({
   const [loading, setLoading] = useState(false)
   // source: probed=真实探测 / fallback=探测失败降级静态表（显示"默认列表"角标 + 重试）。
   const [source, setSource] = useState<'probed' | 'fallback'>('probed')
+  const [probeError, setProbeError] = useState<string | null>(null)
   // CLI 自己当前配置的模型（codex config.toml / ACP currentModelId / claude resolved）。用于胶囊
   // 显示真实名字并在用户未显式选择时自动同步；null = 该 CLI 无「当前」概念 → 显示「自动」。
   const [currentModel, setCurrentModel] = useState<string | null>(null)
@@ -343,6 +344,7 @@ function ExternalModelSelectorBase({
           setReasoningOptions(result.reasoningOptions)
           setReasoningByModel(result.reasoningByModel ?? {})
           setSource(result.source)
+          setProbeError(result.probeError ?? null)
           setCurrentModel(result.currentModel ?? null)
           setCurrentReasoning(result.currentReasoning ?? null)
           // 自动同步 CLI 当前配置：仅当用户未显式选择（externalModel 空 / 'default'）时。
@@ -373,10 +375,11 @@ function ExternalModelSelectorBase({
             onModelChangeRef.current(nextModel, nextReasoning)
           }
         })
-        .catch(() => {
+        .catch((error: unknown) => {
           if (modelsReqIdRef.current !== reqId) return
           // 不再静默吞错：置为降级态，展示重试。保留上次模型列表不清空。
           setSource('fallback')
+          setProbeError(error instanceof Error ? error.message : String(error))
         })
         .finally(() => {
           if (modelsReqIdRef.current === reqId) setLoading(false)
@@ -391,6 +394,7 @@ function ExternalModelSelectorBase({
       lastAgentIdRef.current = agentId
       // 换 agent：旧 CLI 的 currentModel 立刻失效（探测中显示「获取中…」而非上个 CLI 的模型名）。
       setCurrentModel(null)
+      setProbeError(null)
       setCurrentReasoning(null)
       setReasoningByModel({})
     }
@@ -508,6 +512,11 @@ function ExternalModelSelectorBase({
                     {t.chatRetry}
                   </button>
                 </div>
+              )}
+              {source === 'fallback' && probeError && (
+                <p className="mx-2 mb-2 max-w-[300px] break-words text-xs text-neutral-500" role="status">
+                  {probeError}
+                </p>
               )}
               {models.length === 0 ? (
                 <div

--- a/src/chat/cliCommandReportData.ts
+++ b/src/chat/cliCommandReportData.ts
@@ -1,0 +1,31 @@
+export type CliReport = { version: 1; agent: 'antigravity'; command: string; output: string }
+type Quota = { group: string; window: string; remaining: number; reset: string }
+
+export function parseCliReport(value: string): CliReport | null {
+  try {
+    const v: unknown = JSON.parse(value)
+    if (!v || typeof v !== 'object') return null
+    const r = v as Record<string, unknown>
+    return r.version === 1 && r.agent === 'antigravity' && typeof r.command === 'string'
+      && typeof r.output === 'string' ? r as CliReport : null
+  } catch { return null }
+}
+
+export function parseQuotas(output: string): Quota[] {
+  const lines = output.trim().split(/\r?\n/).filter(Boolean)
+  const rows: Quota[] = []
+  for (const line of lines) {
+    const match = line.match(/^(.+?)\s+(Weekly|Five Hour) Limit Remaining\s+(\d+(?:\.\d+)?)%\s+(\S+)\s*$/)
+    if (!match || Number(match[3]) > 100 || !Number.isFinite(Date.parse(match[4]))) return []
+    rows.push({ group: match[1].trim(), window: match[2] === 'Weekly' ? '每周额度' : '5 小时额度', remaining: Number(match[3]), reset: match[4] })
+  }
+  return rows
+}
+
+// Exact old agy quota reports only; ordinary prose and incomplete streams are unchanged.
+export function normalizeLegacyCliReport(content: string): string {
+  return parseQuotas(content).length ? '```kivio-cli-report\n' + JSON.stringify({
+    version: 1, agent: 'antigravity', command: 'usage', output: content,
+  }) + '\n```' : content
+}
+

--- a/src/chat/externalCliSlashCommands.test.ts
+++ b/src/chat/externalCliSlashCommands.test.ts
@@ -3,6 +3,15 @@ import { mapExternalCliSlashCommands } from './externalCliSlashCommands'
 import { commandMatches } from './slashCommands'
 
 describe('mapExternalCliSlashCommands', () => {
+  it('maps Antigravity reports and namespaced skills to native CLI items', () => {
+    const commands = mapExternalCliSlashCommands('antigravity', [
+      { name: 'usage', slash: '/usage', description: 'Quota' },
+      { name: 'plugin:review', slash: '/plugin:review', argumentHint: 'task' },
+    ])
+    expect(commands.every((item) => item.category === 'Antigravity CLI' && item.kind === 'cli')).toBe(true)
+    expect(commands[1].argumentHint).toBe('task')
+    expect(commandMatches(commands[1], 'review')).toBe(true)
+  })
   it('maps probed Claude commands into slash popover items', () => {
     const commands = mapExternalCliSlashCommands('claude', [
       { name: 'compact', slash: '/compact', description: 'Compact history' },

--- a/src/chat/externalCliSlashCommands.ts
+++ b/src/chat/externalCliSlashCommands.ts
@@ -35,6 +35,8 @@ function agentDisplayName(agentId: string): string {
       return 'Grok CLI'
     case 'dsh':
       return 'DeepSeek Harness'
+    case 'antigravity':
+      return 'Antigravity CLI'
     default:
       return agentId
   }

--- a/src/settings/ExternalAgentsSettings.tsx
+++ b/src/settings/ExternalAgentsSettings.tsx
@@ -508,6 +508,13 @@ function AgentDetail({
       {agent.id === 'dsh' && !agent.available && (
         <p className="kv-row-desc">{t.externalAgentsDshInstallHint}</p>
       )}
+      {agent.id === 'antigravity' && (
+        <p className="kv-row-desc">
+          {lang === 'zh'
+            ? '首次使用请在终端运行 agy 完成登录。默认遵循 CLI 权限配置，需要确认的操作可能被拒绝；可在聊天底栏选择权限模式。'
+            : 'Run agy in a terminal to sign in first. Native CLI permissions apply by default; operations requiring confirmation may be denied. Choose a permission mode in the chat composer.'}
+        </p>
+      )}
       {(running || result === 'fail') && (
         <div className="kv-cli-card">
           <div className="kv-row-stack">


### PR DESCRIPTION
接入 Google 官方 Antigravity CLI（`agy`），让用户可以在 Kivio 中选择模型、持续对话、查看工具调用，并通过 `/` 菜单执行已适配命令。

## 改动

- 新增原生 stream-json 会话适配：保存 CLI 会话 ID，多轮复用、取消进程树，并在下一轮恢复；失败轮次不自动重放。
- 接入安装/更新识别、模型及推理强度、权限模式；模型探测允许 60 秒，超时清理子进程并显示错误原因。
- `/` 命令列表由 Kivio 内置维护，随版本更新。报告命令独立执行，技能命令透传原生会话。
- 命令结果显示为面板：配额进度及本地重置时间、可搜索的命令/技能列表、配置列表和折叠原始输出；兼容旧配额消息。

## 验证

- 最新 main 上：28 项相关前端测试通过，`npx tsc --noEmit` 通过。
- 最新 main 上 Rust 测试目标编译、链接成功，但测试进程启动失败：Windows `0xc0000139 / STATUS_ENTRYPOINT_NOT_FOUND`，本轮未能执行 Rust 测试。适配原分支此前的 12 项相关 Rust 单元测试通过；需由 CI 或修复本地运行环境后补验。
- 适配开发阶段在 Windows / agy 1.1.26 上通过真实多轮、工具调用、命令/技能、取消与恢复测试；已检查浅色、深色和窄窗口展示。

## 当前边界

`/model`、`/effort` 等配置命令提供只读查询，修改使用 Kivio 现有控件。交互式终端专属命令不冒充可执行菜单项；原生图片输入、steering 和审批 RPC 暂不支持。

本 PR 基于最新 main 单独整理，仅包含 Antigravity 的四个提交，不包含并行开发的插件与 workflow hooks 改动。

